### PR TITLE
feat(governance): align runtime with feature-branch+PR flow (ADR-0009)

### DIFF
--- a/bootstrap/commands/implement.md
+++ b/bootstrap/commands/implement.md
@@ -16,6 +16,21 @@ Implement the plan. You are the single author. No subagent delegation.
 
 ### Phase 1 — Orient
 
+**Branch guard (ADR-0009):** Before reading any files, check the current branch:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+- If result is `main`: **STOP.** Create a feature branch first:
+  ```bash
+  git checkout -b feat/<short-slug>-<issue-number>
+  ```
+  Use the issue number from `plan.md` footer (`Closes #NNN`). Slug: 2–4 lowercase words from the issue title. Example: `feat/branch-strategy-adr-14`.
+- If result is already a feature branch: proceed.
+
+Note: `bootstrap/commands/implement.md` is installed to `~/.claude/commands/` via `./bootstrap/universal-setup.sh --install`. Changes here require re-install to take effect.
+
 1. Read `plan.md` completely. Read every file referenced in it.
 2. Read 3–5 related files for context (neighbouring modules, existing patterns).
 3. Check relevant ADRs (`docs/decisions/`) for constraints.

--- a/bootstrap/hooks/pre-commit-governance.sh
+++ b/bootstrap/hooks/pre-commit-governance.sh
@@ -5,7 +5,8 @@
 # Получает на stdin JSON: {"tool_input":{"command": "..."}, "cwd": "..."}
 # Возвращает exit 0 для пропуска, exit 2 с JSON для блокировки.
 #
-# Правила:
+# Правила (в порядке выполнения):
+#   4. (first) Запрет direct commit на main (ADR-0009); carve-out: chore:/build: bootstrap/initial
 #   1. Conventional Commits prefix в message
 #   2. Ссылка на issue (#NNN или Closes #NNN) в message или branch name
 #   3. Ссылка на ADR (docs/decisions/NNNN-*.md) для decision-type changes
@@ -53,6 +54,28 @@ cd "$cwd" 2>/dev/null || {
     exit 0
 }
 
+# --- Extract branch (needed by Rule 4, which runs before message-dependent rules) ---
+
+# fail-open on detached HEAD (returns "HEAD", not "main") / fresh clone (error → "")
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+# --- Rule 4: No direct commits to main (ADR-0009) ---
+# Placed before amend-skip and message rules so it fires first.
+# This means `git commit --amend` on main is also blocked — intentional.
+# ADR commits land on main via `gh pr merge` (API call, hook not triggered) — no carve-out needed.
+# Carve-out: bootstrap/initial meta-commits scoped to chore:/build: prefix with word-boundary
+# to prevent "feat: add initial thing (#N)" from bypassing.
+
+if [ "$branch" = "main" ]; then
+    msg_for_rule4=$(echo "$command" | grep -oE '\-m\s+"[^"]*"' | head -1 | sed -E 's/^-m[ ]+"(.*)"$/\1/')
+    if [ -z "$msg_for_rule4" ]; then
+        msg_for_rule4=$(echo "$command" | grep -oE "\-m\s+'[^']*'" | head -1 | sed -E "s/^-m[ ]+'(.*)'$/\1/")
+    fi
+    if ! echo "$msg_for_rule4" | grep -qE '^(chore|build)(\([a-z0-9_.-]+\))?!?:\s+.*\b(bootstrap|initial)\b'; then
+        json_deny "Direct commits to 'main' are not allowed (ADR-0009). Create a feature branch first: git checkout -b feat/<slug>-<issue-number>. Carve-out: chore:/build: bootstrap/initial commits only."
+    fi
+fi
+
 # --- Extract commit message ---
 
 # Case 1: git commit -m "..."
@@ -65,10 +88,10 @@ if echo "$command" | grep -qE '\-\-amend'; then
     exit 0
 fi
 
-msg=$(echo "$command" | grep -oE '\-m\s+"[^"]*"' | head -1 | sed -E 's/^-m\s+"(.*)"$/\1/')
+msg=$(echo "$command" | grep -oE '\-m\s+"[^"]*"' | head -1 | sed -E 's/^-m[ ]+"(.*)"$/\1/')
 
 if [ -z "$msg" ]; then
-    msg=$(echo "$command" | grep -oE "\-m\s+'[^']*'" | head -1 | sed -E "s/^-m\s+'(.*)'$/\1/")
+    msg=$(echo "$command" | grep -oE "\-m\s+'[^']*'" | head -1 | sed -E "s/^-m[ ]+'(.*)'$/\1/")
 fi
 
 if [ -z "$msg" ]; then
@@ -84,8 +107,6 @@ if ! echo "$msg" | grep -qE "$cc_regex"; then
 fi
 
 # --- Rule 2: Issue reference ---
-
-branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 
 has_issue_ref=false
 if echo "$msg" | grep -qE '#[0-9]+'; then

--- a/docs/decisions/0009-feature-branch-pr-flow.md
+++ b/docs/decisions/0009-feature-branch-pr-flow.md
@@ -1,0 +1,121 @@
+# 0009. Feature-branch + PR flow for solo pipeline
+
+* Status: accepted
+* Date: 2026-04-23
+* Deciders: venil (operator decides; draft by solutions-architect)
+* Tags: workflow, governance, process
+
+## Context and Problem Statement
+
+Relates to: #14
+
+Первый реальный прогон `/feature` обнажил рассинхрон между документом и рантаймом: `CLAUDE.md` и `.claude/commands/feature.md` декларируют PR-based flow (step 11: `gh pr create`), но фактический запуск закоммитил напрямую в `main`, потому что feature-ветка никогда не создавалась. `gh pr create` из `main → main` предсказуемо упал. Проект — solo dev + AI-assisted pipeline; нужно решить, какой из двух флоу является каноничным, и выровнять код/доки под него. Решение архитектурно-значимо: меняет Definition of Done (`docs/principles.md#definition-of-done` уже предполагает PR), governance hook (`ADR-0004`), и три runbook'а.
+
+## Decision Drivers
+
+* **Согласованность документ↔рантайм.** DoD, `/feature`, runbook уже написаны под PR-flow. Любое решение должно выровнять все три слоя.
+* **Reversibility.** Насколько дёшево откатить плохое изменение до того, как оно попало в публичную историю `main`.
+* **Ceremony-per-task cost.** Сколько шагов человек делает на каждую задачу. Solo dev чувствителен к friction больше, чем team.
+* **Enforceability governance'а.** Hook должен детерминированно блокировать нарушения; полагаться на дисциплину solo — неустойчиво (третья директива `docs/principles.md` §3: автоматизировать только низкорискованное).
+* **Готовность к росту ≥2 контрибьюторов.** Смена флоу позже дороже, чем решение один раз сейчас.
+* **Стоимость CI.** Flow, полагающийся на PR-ворота, требует работающего CI; без required checks PR-merge превращается в формальность.
+
+## Considered Options
+
+* **Option A: main-only commit flow.** `/review` + `/codex-review` — единственные ворота; после них `git commit` на `main` + `git push`. Никакой feature-ветки, никакого PR. Issue закрывается по `Closes #NNN` в commit message.
+* **Option B: feature-branch + PR flow (canonical).** На каждый task — отдельная ветка `feat/<slug>-<issue>`; после `/review`+`/codex-review` — `gh pr create`; auto-merge при зелёном CI. Текущее заявленное поведение.
+* **Option C: feature-branch + fast-forward merge without PR.** Компромисс: ветка создаётся (reversibility до push + изолированная история), но merge идёт `git merge --ff-only` локально, без `gh pr create`. Отпадает CI-gate и PR UI, остаётся структура истории.
+
+## Decision Outcome
+
+Chosen option: **Option B (feature-branch + PR flow)**. **Reversibility classification: reversible door** — the decision can be walked back to Option A at any time while the project remains solo; it becomes a one-way door at ≥2 contributors (see Re-visit Trigger #1).
+
+Обоснование: документированный контракт проекта (`docs/principles.md` DoD пп. "CI зелёный на всех required jobs" и "PR body ссылается на issue и ADR"; `CLAUDE.md` hard rule #3 "Cross-ref в PR"; `/feature` step 11; `docs/runbooks/feature-pipeline.md` §10) уже предполагает PR-flow на трёх уровнях. Сбой в runtime — это drift, не ошибка контракта. Выравнивание runtime к документу дешевле, чем переписывание документа, DoD, и runbook под Option A, и сохраняет готовность к multi-contributor без миграции. Ссылка на принципы: четвёртая директива (`docs/principles.md` §4 «Knowledge в инструментах, не в памяти») — PR-артефакт в GitHub — это durable knowledge с threaded review, advisor/codex findings прикрепляются к PR-комментам и переживают сессию; main-only flow теряет этот слой. Уникальность репо («проект документирует и устанавливает сам себя») усиливает: pipeline должен уметь произвести любой артефакт — в том числе PR для самого себя.
+
+Option A отклонён как рационализация текущего runtime-сбоя: «раз упало на PR, давайте уберём PR». Это инверсия причинности. Option C отклонён как полумера — он даёт reversibility, но не даёт threaded review, CI-gate, или артефакт для future archaeology; экономия 1 шага (`gh pr create`) не оправдывает потерю.
+
+### Positive Consequences
+
+* Runtime выравнивается с уже написанным контрактом — никакой ретро-правки DoD, `CLAUDE.md`, runbook.
+* Reversibility: ошибочную ветку можно закрыть без merge; плохой `main`-commit откатывается только force-push или revert-коммитом (hostile к archaeology).
+* Advisor/codex-review findings живут на PR-странице как threaded comments — durable knowledge, соответствует 4-й директиве.
+* CI gate срабатывает до попадания в `main`; `required checks` делают DoD-пункт «CI зелёный» enforceable, а не аспирационным.
+* Zero migration cost при переходе к ≥2 контрибьютора.
+
+### Negative Consequences
+
+* **+2–3 шага на каждую задачу:** `git checkout -b`, `gh pr create`, `gh pr merge`. Для solo dev с 5–10 задач/неделю — 10–30 дополнительных действий; на длинной дистанции создаёт усталость и соблазн срезать.
+* **Требует изменения governance hook (`ADR-0004`):** добавить правило «deny commit when `branch == main`», иначе защита только декларативная. Hook amendment входит в scope этого PR (#14) — отдельный ADR не нужен.
+* **Требует рабочего CI с required checks.** Если CI нет / он сломан / он медленный — PR-merge деградирует в rubber-stamp. Сейчас CI в репо в зачаточном состоянии — факт, который нужно закрыть параллельно, иначе PR-flow даёт false sense of safety.
+* **Auto-merge на Claude Max solo — ceremonial theatre.** «Сам себе ревьювер» через PR UI — это cosplay командного процесса; риск, что оператор начнёт мерджить не читая, потому что «всё равно мои же коммиты». Mitigation — advisor и codex-review должны реально отрабатывать до merge; если они skip'аются, PR-flow теряет смысл.
+* **`/implement` нужно явно учить создавать ветку до первого edit.** Забыть — значит воспроизвести текущий баг; требуется enforcement (hook "not on main" ловит это после факта, но лучше early-fail в `/implement` Phase 1).
+
+## Pros and Cons of the Options
+
+### Option A: main-only commit flow
+
+* Good, потому что минимальная ceremony — 1 команда `git commit` вместо 3.
+* Good, потому что нет зависимости от CI/PR-UI — работает офлайн.
+* Good, потому что honest для solo: никакой cosplay «командного review».
+* Bad, потому что теряется reversibility — плохой commit уже в публичной истории; revert ≠ never-happened.
+* Bad, потому что конфликтует с `docs/principles.md` DoD (CI, PR body, Closes, Implements-ADR) — требует переписывания DoD, `CLAUDE.md` hard rule #3, `/feature` step 11, `docs/runbooks/feature-pipeline.md` §10, `.github/pull_request_template.md`. Doc-surface impact значительно больше, чем «3 файла».
+* Bad, потому что governance hook (`ADR-0004`) полагается на `branch` как источник issue-ref; при `branch == main` issue-ref обязателен **только** в message — забыл `#NNN` = hard block, и это станет частой блокировкой.
+* Bad, потому что advisor/codex findings теряют durable surface (нет PR-комментов) — остаются только в локальной сессии Claude. Регресс против 4-й директивы.
+* Bad, потому что миграция к ≥2 контрибьюторам требует полного reverse решения.
+
+### Option B: feature-branch + PR flow (chosen)
+
+* Good, reversibility до push + до merge.
+* Good, durable artefact (PR) с threaded review — 4-я директива.
+* Good, CI-gate enforceable, а не декларативный.
+* Good, zero rewrite действующих доков (DoD, runbook, `/feature`).
+* Good, готовность к multi-contributor без миграции.
+* Bad, +2–3 шага на task; solo dev friction.
+* Bad, требует поправки hook'а («not on main») и обучения `/implement` создавать ветку.
+* Bad, требует минимального рабочего CI; без него PR-flow — театр.
+* Bad, auto-merge solo = self-review; нужен явный guardrail что advisor/codex отработали.
+* Bad, форж-lock-in: `gh pr create`, auto-merge, PR-template жёстко привязывают pipeline к GitHub; миграция на GitLab/Gitea/Forgejo потребует переписывания команд и runbook'ов.
+
+### Option C: feature-branch + fast-forward merge without PR
+
+* Good, reversibility до локального merge (можно удалить ветку).
+* Good, изолированная история до готовности.
+* Good, экономит 2 шага по сравнению с B (нет `gh pr create`/`gh pr merge`).
+* Good, не требует CI — как и A.
+* Bad, теряет durable review artefact — ветка удаляется, комментариев нет.
+* Bad, не enforceable CI-gate — как A.
+* Bad, гибрид, который документируется сложнее, чем каждый из чистых вариантов.
+* Bad, всё равно требует hook-правила «not on main» и обучения `/implement` ветке — стоимость как у B, польза как у A.
+
+## Confirmation
+
+Критерии валидации решения после принятия:
+
+1. **Runtime match.** Следующий реальный прогон `/feature <N>` завершается merged PR, а не commit в `main`. Проверка: `git log main --first-parent -5` показывает merge-commits, не direct commits.
+2. **Hook enforcement.** Rule 4 добавлена в `bootstrap/hooks/pre-commit-governance.sh`: `if branch == "main" && msg не matching ^(chore|build):.*\b(bootstrap|initial)\b: deny`. После merge запустить `./bootstrap/universal-setup.sh --install` для обновления установленного hook'а. Smoke-test (как в ADR-0004) с `main` checkout и плохим input'ом — exit 2.
+3. **`/implement` early-fail.** `.claude/commands/implement.md` Phase 1 явно включает `git checkout -b feat/<slug>-<issue>` как первый шаг; если ветка уже `main` — STOP.
+4. **Runbook sync.** `docs/runbooks/feature-pipeline.md` §5 (Implementation) упоминает создание ветки; §10 остаётся как есть.
+5. **Ceremony budget.** Через 30 дней проверить skip-rate PR-ceremony. Если skip-rate >20% за месяц → см. Re-visit Trigger #4.
+6. **Forge-abstraction audit.** Все GitHub-specific команды (`gh pr create`, `gh pr merge`, `gh pr view`, PR-template) перечислены в `docs/runbooks/feature-pipeline.md` §11 «Forge lock-in surface». Цель — при будущей миграции forge scope замены известен заранее, а не обнаруживается по ошибкам.
+
+## Re-visit Trigger
+
+Решение пересматривается при выполнении хотя бы одного:
+
+* **Рост до ≥2 контрибьюторов.** Option A/C становятся невалидны — Option B единственный вариант, ADR закрывается как «superseded by reality».
+* **CI становится медленнее 60 сек на merge И <1 revert в месяц за 3 месяца подряд.** PR-gate перестаёт окупаться — пересмотр в пользу C.
+* **Claude Code получает native governance для workflow (branch policy в `settings.json`).** Hook-правила мигрируют туда, формулировка ADR обновляется.
+* **Skip-рейт PR-ceremony >20% за месяц** (оператор коммитит напрямую в main в обход pipeline). Значит friction реально превышает ценность — честно пересмотреть в пользу A, не делая вид что всё работает.
+* **Миграция с GitHub на другой forge.** Лок-ин материализуется — ADR пересматривается с учётом tooling нового forge.
+
+## Links
+
+* `0004-governance-via-prehook.md` — governance hook; требует поправки «deny commit on main» при принятии Option B.
+* `0002-pipeline-over-fanout.md` — single-author pipeline; neither option conflicts, но Option B сохраняет invariant «один автор на PR».
+* `0005-two-voice-review-codex-plus.md` — Claude + Codex review; findings лучше living в PR-комментах (B) чем в эфемерной сессии (A/C).
+* `../principles.md#definition-of-done` — уже предполагает PR-flow; Option A требует его правки.
+* `../principles.md#что-значит-архитектурно-значимо` — смена модели безопасности/процесса merge попадает под «ограничение, которое трудно снять через 6 месяцев».
+* `../runbooks/feature-pipeline.md` §10 — должен остаться как есть при B, переписан при A.
+* `.claude/commands/feature.md` step 11 — `gh pr create` остаётся при B, удаляется при A.
+* `.claude/commands/implement.md` — Phase 1 дополняется `git checkout -b` при B/C.
+* Issue #14 — acceptance criteria этого ADR.

--- a/docs/runbooks/feature-pipeline.md
+++ b/docs/runbooks/feature-pipeline.md
@@ -66,6 +66,15 @@ advisor("Review this plan against codebase. Missing edge cases? ADR violations?"
 
 ### 5. Implementation
 
+Before running `/implement`, create the feature branch if you haven't already:
+
+```bash
+git checkout -b feat/<short-slug>-<issue-number>
+# Example: git checkout -b feat/retry-logic-42
+```
+
+The governance hook (ADR-0009) blocks direct commits to `main`; creating the branch here avoids a stash/rebase recovery later.
+
 ```
 /implement
 ```
@@ -120,6 +129,19 @@ PR body должен включать:
 - `Closes #<issue>`
 - `Implements docs/decisions/NNNN-*.md` если был ADR
 - DoD checklist из `.github/pull_request_template.md`
+
+### 11. Forge lock-in surface
+
+The following GitHub-specific commands and files are used in this pipeline. This inventory exists so a future forge migration has known, enumerated scope rather than surprise discovery. **Update this section when adding new `gh` commands.**
+
+| Artifact | Location | Notes |
+|---|---|---|
+| `gh pr create` | Step 10 above; `bootstrap/commands/feature.md` step 11 | Creates PR from feature branch |
+| `gh pr merge` | Operator post-review; `docs/decisions/0009-feature-branch-pr-flow.md` | Merges PR to main |
+| `gh pr view` | `/review` skill, `/codex-review` skill | Reads PR metadata and diff |
+| `gh issue view` | `bootstrap/commands/feature.md` line 11 | Loads issue JSON for `/feature` |
+| `.github/pull_request_template.md` | `.github/pull_request_template.md` | PR body DoD checklist |
+| `.github/workflows/ci.yml` | `.github/workflows/ci.yml` | CI gate for required checks |
 
 ## Master orchestrator
 


### PR DESCRIPTION
## Summary

- Adds Rule 4 to `pre-commit-governance.sh`: deny direct commits to `main` (carve-out: `chore:/build:` bootstrap/initial only)
- Fixes pre-existing macOS BSD sed `\s+` bug in all 4 message-extraction calls
- Adds Phase 1 branch guard to `implement.md`: STOP if on `main`, create `feat/` branch first
- Adds branch-creation step to `feature-pipeline.md` §5 and new §11 Forge lock-in surface inventory
- Flips ADR-0009 status `proposed → accepted`; removes "pending confirmation" language

Closes #14
Implements docs/decisions/0009-feature-branch-pr-flow.md

## Post-merge checklist

- [ ] Run `./bootstrap/universal-setup.sh --install` to update the installed hook and implement.md
- [ ] Smoke-test Rule 4: `git checkout main` → attempt a `feat:` commit → expect exit 2
- [ ] Return to feature branch: `git checkout feat/branch-strategy-adr-14` (or `main` after merge)
- [ ] Open follow-up issue: document drift between `bootstrap/hooks/pre-commit-governance.sh` and `~/.claude/hooks/pre-commit-governance.sh` (completely different files — Python3 shlex vs grep/sed, different rule set)

## Review notes

- `--amend` on `main` is intentionally blocked by Rule 4 (runs before the amend-skip exit)
- `\s`/`\b` in `grep -E` are valid on macOS BSD grep and GNU grep; only BSD `sed -E` lacked support (fixed)
- `json_deny` JSON-escaping pre-existing bug (line 97) left as follow-up — not in scope for #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)