### PR TITLE
feat(bootstrap): add missing /plan command to bootstrap source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 .vscode/
 .idea/
 *.swp
-plan.md
+/plan.md
 *.bak
 deploy-to-github.sh
 create-backlog.sh

--- a/bootstrap/commands/plan.md
+++ b/bootstrap/commands/plan.md
@@ -1,0 +1,47 @@
+---
+description: Plan a change against the current issue. Writes plan.md; does not touch code.
+argument-hint: [issue-number]
+allowed-tools: Bash(gh issue view:*), Bash(gh label list:*), Read, Glob, Grep, Write
+model: claude-sonnet-4-6
+---
+
+# /plan
+
+Issue context: !`gh issue view $ARGUMENTS --json number,title,body,labels,milestone,assignees`
+Domain docs (если есть): @docs/domain/
+Principles: @docs/principles.md
+Related ADRs: !`ls docs/decisions/ 2>/dev/null | tail -5`
+
+## Your task
+
+Produce `plan.md` in the repo root with exactly these sections:
+
+1. **Problem restatement** — one paragraph in your own words, not a copy of the issue.
+2. **Affected bounded contexts and files** — list with paths. If domain docs exist, name the BCs explicitly.
+3. **Considered approaches** — at least 2, with trade-offs. Если только один очевидный путь и он действительно единственный — скажи это явно и обоснуй.
+4. **Chosen approach and why** — reference relevant ADRs if any exist.
+5. **Test strategy** — unit / integration / e2e split, what assertions matter.
+6. **Risks and unknowns** — honest list; "none" is a smell.
+
+## Gating
+
+After writing plan.md, check the "Architectural significance" criteria in `docs/principles.md`. If any is triggered:
+
+> **STOP.** This change has architectural implications. Before `/implement`:
+>
+> 1. Invoke `@agent-solutions-architect` to produce an ADR draft.
+> 2. Wait for ADR PR to merge.
+> 3. Then proceed to `/implement`.
+
+If not architectural:
+
+> Plan written to `plan.md`. Next steps:
+>
+> 1. Call advisor() to critique the plan.
+> 2. Run `/implement` when plan is sound.
+
+## Hard rules
+
+- You do NOT write code. Only `plan.md`.
+- You do NOT skip "Considered approaches" with just one option unless you justify why.
+- You DO read files referenced in the issue body — plan must be grounded in actual code.


### PR DESCRIPTION
## Summary

- `bootstrap/commands/plan.md` was never committed to the repo — it existed only as an orphaned file in `~/.claude/commands/` on the dev machine. `universal-setup.sh` could therefore never deploy it to mini.
- Anchors `.gitignore` pattern from `plan.md` to `/plan.md` (root-only), so `bootstrap/commands/plan.md` is no longer silently excluded from version control.
- Removes unused `Bash(gh pr list:*)` from `allowed-tools` (caught by `/review`).

## Closes / Implements

Closes #3

## DoD checklist

- [x] ADR opened and merged — N/A: not architecturally significant (confirmed by solutions-architect review; issue is story-level)
- [x] `/review` approved — no BLOCK findings
- [ ] `/codex-review` approved — **SKIPPED** (Plus-OAuth timeout, exit 124). Deferred-review issue: #33. Two-voice DoD criterion not satisfied; merge is not blocked per graceful-degradation policy.
- [x] Conventional Commits; governance hook passed
- [x] PR references issue (`Closes #3`)
- [ ] AC verification on mini — **post-merge operator action**: `git pull` on mini → `./bootstrap/universal-setup.sh --install` → verify `ls` counts (see issue #3 AC). Operator to post `ls` output as issue comment.

## Follow-up issues filed during this work

- #31 — Bootstrap completeness: implicit tree vs explicit manifest (`adr-needed`)
- #32 — Installer does not remove orphans: target-only artifacts persist (`adr-needed`)
- #33 — Deferred codex review: 758839e (`type:deferred-review`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)