### PR TITLE
feat(governance): smoke-test hook with all 4 bad-commit patterns

### DIFF
--- a/bootstrap/scripts/mini-health.sh
+++ b/bootstrap/scripts/mini-health.sh
@@ -70,18 +70,19 @@ fi
 
 # --- Governance hook smoke-test ---
 echo ""
-echo "Governance hook smoke-test (должен отвергнуть bad commit):"
+echo "Governance hook (все 6 паттернов из ADR-0004):"
+test_script="$HOME/.claude/scripts/test-governance-hook.sh"
 hook_path="$HOME/.claude/hooks/pre-commit-governance.sh"
-if [ -x "$hook_path" ]; then
-    test_input='{"tool_input":{"command":"git commit -m \"bad msg\""},"cwd":"'"$PWD"'"}'
-    result=$(echo "$test_input" | "$hook_path" 2>/dev/null; echo "exit=$?")
-    if echo "$result" | grep -q "exit=2"; then
-        ok "Hook корректно отвергает bad commit"
-    else
-        fail "Hook должен был exit 2, но вернул: $result"
-    fi
+if [ ! -x "$hook_path" ]; then
+    warn "Governance hook не установлен: $hook_path"
+elif [ ! -x "$test_script" ]; then
+    warn "Hook test script не установлен: $test_script"
 else
-    warn "Governance hook не установлен или неисполняем"
+    if bash "$test_script" >/dev/null 2>&1; then
+        ok "Hook smoke-test: все 6 паттернов прошли"
+    else
+        fail "Hook smoke-test упал — запусти: bash $test_script"
+    fi
 fi
 
 # --- gh & codex auth ---

--- a/bootstrap/scripts/test-governance-hook.sh
+++ b/bootstrap/scripts/test-governance-hook.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# test-governance-hook.sh — smoke-test for pre-commit-governance.sh
+#
+# Verifies all 4 bad-commit patterns are blocked (exit 2) and
+# 2 good-commit patterns are allowed (exit 0), without going through Claude.
+#
+# Usage:
+#   bash ~/.claude/scripts/test-governance-hook.sh
+#   # or from repo: bash bootstrap/scripts/test-governance-hook.sh
+#
+# Exit codes: 0 = all tests passed, 1 = one or more failures
+
+set -uo pipefail
+
+HOOK="${1:-$HOME/.claude/hooks/pre-commit-governance.sh}"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'; NC='\033[0m'
+pass() { printf "  ${GREEN}✓${NC} %s\n" "$1"; }
+fail() { printf "  ${RED}✗${NC} %s\n" "$1"; FAILURES=$((FAILURES+1)); }
+
+FAILURES=0
+
+# --- Preflight ---
+
+if [ ! -x "$HOOK" ]; then
+    printf "${RED}FATAL:${NC} hook not found or not executable: %s\n" "$HOOK" >&2
+    echo "Install with: ./bootstrap/universal-setup.sh --install" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    printf "${RED}FATAL:${NC} jq is required but not installed\n" >&2
+    exit 1
+fi
+
+echo "=== Governance hook smoke-test ==="
+echo "Hook: $HOOK"
+echo ""
+
+# --- Temp repo setup ---
+# Branch must be 'smoketest' (no digits, not 'main'):
+#   - no digits → Rule 2 fires correctly for no-issue-ref cases
+#   - not 'main' → Rule 4 (no direct commits to main) doesn't fire, masking other rules
+
+TMPDIR_REPO=$(mktemp -d /tmp/claude-mini-hook-test-XXXXXX)
+trap 'rm -rf "$TMPDIR_REPO"' EXIT
+
+git -C "$TMPDIR_REPO" init -q
+# Set branch to 'smoketest' (no digits, not 'main') before first commit.
+# symbolic-ref is used directly because 'git init --initial-branch' on an
+# already-initialized repo may succeed but silently leave the branch unchanged.
+git -C "$TMPDIR_REPO" symbolic-ref HEAD refs/heads/smoketest
+
+git -C "$TMPDIR_REPO" config user.email "test@example.com"
+git -C "$TMPDIR_REPO" config user.name "Test"
+
+# Create initial commit so 'git diff --cached' works
+touch "$TMPDIR_REPO/README.md"
+git -C "$TMPDIR_REPO" add README.md
+git -C "$TMPDIR_REPO" commit -q -m "chore: initial commit"
+
+# --- Helper ---
+
+run_hook() {
+    local cmd="$1"
+    local cwd="${2:-$TMPDIR_REPO}"
+    # Use jq to build JSON so embedded quotes in cmd are properly escaped
+    jq -n --arg cmd "$cmd" --arg cwd "$cwd" \
+        '{"tool_input":{"command":$cmd},"cwd":$cwd}' \
+        | "$HOOK" 2>/dev/null
+    echo "exit=$?"
+}
+
+assert_blocked() {
+    local label="$1"
+    local cmd="$2"
+    local expected_reason_substr="$3"
+    local cwd="${4:-$TMPDIR_REPO}"
+
+    result=$(run_hook "$cmd" "$cwd")
+    exit_code=$(echo "$result" | grep -oE 'exit=[0-9]+' | tail -1 | cut -d= -f2)
+    reason=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecisionReason // ""' 2>/dev/null || echo "")
+
+    if [ "$exit_code" != "2" ]; then
+        fail "$label — expected exit 2, got exit $exit_code"
+        return
+    fi
+    if [ -z "$reason" ]; then
+        fail "$label — exit 2 but deny reason is empty"
+        return
+    fi
+    if ! echo "$reason" | grep -qi "$expected_reason_substr"; then
+        fail "$label — exit 2 but wrong rule fired. Expected reason containing '$expected_reason_substr', got: $reason"
+        return
+    fi
+    pass "$label"
+}
+
+assert_allowed() {
+    local label="$1"
+    local cmd="$2"
+    local cwd="${3:-$TMPDIR_REPO}"
+
+    result=$(run_hook "$cmd" "$cwd")
+    exit_code=$(echo "$result" | grep -oE 'exit=[0-9]+' | tail -1 | cut -d= -f2)
+
+    if [ "$exit_code" != "0" ]; then
+        reason=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecisionReason // ""' 2>/dev/null || echo "")
+        fail "$label — expected exit 0, got exit $exit_code. Reason: $reason"
+        return
+    fi
+    pass "$label"
+}
+
+# --- Bad commit cases (must be blocked) ---
+
+echo "Bad commits (must be blocked with exit 2):"
+
+# Rule 1: no Conventional Commits prefix
+assert_blocked \
+    "no CC prefix" \
+    'git commit -m "just did some stuff"' \
+    "Conventional Commits"
+
+# Rule 2: no issue-ref (branch 'smoketest' has no digits)
+assert_blocked \
+    "no issue-ref" \
+    'git commit -m "feat: add new thing"' \
+    "issue"
+
+# Rule 3: decision-type change (docs/domain/ staged) without ADR-ref
+# Stages docs/domain/test-entity.md — matches decision_markers but NOT ^docs/decisions/[0-9]+-.*\.md$
+# (which would set has_adr_ref=true and falsely allow)
+mkdir -p "$TMPDIR_REPO/docs/domain"
+echo "test" > "$TMPDIR_REPO/docs/domain/test-entity.md"
+git -C "$TMPDIR_REPO" add docs/domain/test-entity.md
+
+assert_blocked \
+    "decision change without ADR-ref (docs/domain/ staged)" \
+    'git commit -m "chore: update adr (#1)"' \
+    "ADR"
+
+# Unstage for subsequent tests
+git -C "$TMPDIR_REPO" restore --staged docs/domain/test-entity.md 2>/dev/null \
+    || git -C "$TMPDIR_REPO" reset HEAD docs/domain/test-entity.md 2>/dev/null || true
+
+# Rule 2 (indirect): breaking change without '!' and no issue-ref
+# NOTE: the hook has no dedicated "must use !" rule. This commit is blocked only because
+# the branch 'smoketest' has no issue number → Rule 2 fires. If the branch contained a
+# number (e.g. feat/something-2), this commit would pass. Gap tracked: add a dedicated
+# breaking-change rule in a follow-up ADR.
+assert_blocked \
+    "breaking change without '!' (blocked via Rule 2 — no issue-ref)" \
+    'git commit -m "feat: rename public API"' \
+    "issue"
+
+echo ""
+
+# --- Good commit cases (must be allowed) ---
+
+echo "Good commits (must be allowed with exit 0):"
+
+assert_allowed \
+    "valid CC + issue ref" \
+    'git commit -m "feat: add X (#1)"'
+
+assert_allowed \
+    "breaking change with '!' + issue ref" \
+    'git commit -m "feat!: rename public API (#1)"'
+
+# --- Summary ---
+
+echo ""
+echo "=== Summary ==="
+if [ "$FAILURES" -eq 0 ]; then
+    printf "${GREEN}All tests passed.${NC} Governance hook is working correctly.\n"
+    exit 0
+else
+    printf "${RED}%d test(s) failed.${NC} See output above.\n" "$FAILURES"
+    echo "If the hook binary fails but was never invoked, check settings.json:"
+    echo "  hook path must be ABSOLUTE (/Users/... not ~/...)"
+    echo "  See docs/runbooks/incident-recovery.md for full diagnosis."
+    exit 1
+fi

--- a/docs/runbooks/incident-recovery.md
+++ b/docs/runbooks/incident-recovery.md
@@ -45,6 +45,59 @@ cd ~/projects/claude-mini && ./bootstrap/universal-setup.sh --install
 #   ./bootstrap/universal-setup.sh --install --force
 ```
 
+### Governance hook молчит (пропускает всё)
+
+**Симптомы:** плохие коммиты (без CC prefix, без issue-ref) проходят без ошибки — Claude коммитит что угодно.
+
+**Отличие от "hook blocks everything":** там hook активен, но слишком строгий. Здесь hook вообще не вызывается.
+
+**Быстрая диагностика:**
+```bash
+# Проверяет hook binary напрямую — минуя settings.json и Claude Code
+bash ~/.claude/scripts/test-governance-hook.sh
+# Ожидание: All tests passed.
+# Если failed → hook binary сломан (см. ниже).
+# Если passed → hook binary рабочий, но Claude Code его не вызывает (см. tilde path).
+```
+
+**Причина 1: Tilde path в settings.json (самая частая)**
+```bash
+jq '.hooks.PreToolUse[] | select(.matcher == "Bash") | .hooks[] | select(.type == "command") | .command' \
+    ~/.claude/settings.json
+# Если видишь "~/.claude/hooks/..." вместо "/Users/venil/.claude/hooks/..."
+# → Claude Code передаёт command в exec без shell expansion, тильда остаётся literal
+```
+
+Исправление:
+```bash
+# Пересмотри hook path в settings.json — должен быть абсолютным
+# Или переустанови:
+cd ~/projects/claude-mini && ./bootstrap/universal-setup.sh --install
+```
+
+**Причина 2: Hook не выставлен исполняемым**
+```bash
+ls -la ~/.claude/hooks/pre-commit-governance.sh
+# Должен быть -rwxr-xr-x
+chmod +x ~/.claude/hooks/pre-commit-governance.sh
+```
+
+**Причина 3: jq не установлен**
+```bash
+which jq || echo "NOT FOUND"
+# Без jq hook падает молча: input не парсится, command пуст, hook пропускает всё
+brew install jq   # macOS
+```
+
+**Причина 4: PreToolUse hook не прописан в settings.json вообще**
+```bash
+jq '.hooks.PreToolUse' ~/.claude/settings.json
+# Должен быть непустым массивом с matcher: "Bash"
+# Если null → переустанови: ./bootstrap/universal-setup.sh --install
+```
+
+**Важно:** `test-governance-hook.sh` тестирует hook binary напрямую. Он не может обнаружить tilde-path проблему (hook вызывается, значит binary рабочий). Если тест прошёл, но плохие коммиты всё равно проходят через Claude — проблема в settings.json, не в hook.
+
 ### MCP server не отвечает
 
 **Симптомы:** `@mcp__github__...` fails, Serena не индексирует.


### PR DESCRIPTION
## Summary

- Adds `bootstrap/scripts/test-governance-hook.sh` — standalone script covering all 4 bad-commit patterns (Rules 1–3) and 2 valid patterns from ADR-0004 AC; callable from terminal without Claude
- Replaces single-pattern inline test in `mini-health.sh` with a call to the new script (6-pattern coverage)
- Adds "Hook молчит (пропускает всё)" section to `docs/runbooks/incident-recovery.md` covering tilde-path gotcha, jq missing, chmod, settings.json not wired

## Closes

Closes #2

## AC status

- [x] `git commit -m "just did some stuff"` → blocked (Rule 1: no CC prefix)
- [x] `git commit -m "feat: add new thing"` → blocked (Rule 2: no issue-ref)
- [x] decision-type change without ADR-ref → blocked (Rule 3)
- [x] `git commit -m "feat: rename public API"` → blocked (Rule 2, indirect — documented gap: no dedicated breaking-change rule)
- [x] `git commit -m "feat: add X (#1)"` → allowed
- [x] `git commit -m "feat!: rename public API (#1)"` → allowed
- [x] `mini-health` diagnostic command added
- [x] Runbook section added for silent-hook failure

**Note:** "breaking change without `!`" is blocked indirectly via Rule 2 (no issue-ref on a no-number branch). The hook has no dedicated `!`-enforcement rule. This gap is documented in test script comments and runbook. A dedicated rule requires ADR discussion — deferred as follow-up.

**Note:** scripts count on mini changes 5 → 6 after install (issue #3 AC #5 becomes stale).

## Key implementation decisions

- Branch named `smoketest` (no digits, not `main`) in temp repo: using `main` would trigger Rule 4 (no direct commits to main) on ALL cases including valid ones, masking Rules 1–3
- JSON built via `jq -n --arg` (not string interpolation) — safe escaping of embedded quotes
- `docs/domain/test-entity.md` staged for Rule 3 (not `docs/decisions/0099-test.md` which would set `has_adr_ref=true` → false-allow)
- Per-rule `permissionDecisionReason` assertion: exit 2 from the wrong rule is a false-positive

## Definition of Done

- [x] ADR: not required (no architectural significance)
- [x] `/review` (Claude): no BLOCKs
- [ ] `/codex-review`: SKIPPED — Plus-OAuth timeout → deferred-review issue #35. DoD gap: two-voice review not satisfied.
- [ ] Human self-review
- [x] Governance hook passed
- [x] `Closes #2` in PR body