### PR TITLE
fix(bootstrap): SSH keepalive to prevent drops during advisor calls

### DIFF
--- a/bootstrap/hardware/mac-mini-2018.md
+++ b/bootstrap/hardware/mac-mini-2018.md
@@ -284,7 +284,42 @@ jq --version
 rg --version
 ```
 
-### 19. Создать platform.done flag
+### 19. SSH connection stability (keepalive)
+
+SSH connections drop during long advisor calls (30–90s silent) when the client has no keepalive configured. Apply on both sides.
+
+**На mini (server-side) — `/etc/ssh/sshd_config`:**
+
+Add or update (do not append a duplicate) the following lines:
+```
+ClientAliveInterval 60
+ClientAliveCountMax 3
+```
+
+Restart sshd:
+```bash
+sudo launchctl kickstart -k system/com.openssh.sshd
+```
+
+Verify effective config (first-match wins; checks include files):
+```bash
+sudo sshd -T | grep -i clientalive
+# Expected: clientaliveinterval 60 / clientalivecountmax 3
+# Total detection window: 3 minutes
+```
+
+**На MacBook (client-side) — `~/.ssh/config`:**
+
+Add or update the `Host mini` block (do not append a duplicate block):
+```
+Host mini
+  ServerAliveInterval 60
+  ServerAliveCountMax 3
+```
+
+**Проверка через preflight:** `mini-preflight.sh` проверяет наличие `ClientAliveInterval` в sshd config и покажет `✓` если всё верно.
+
+### 20. Создать platform.done flag
 
 После успешного прохождения всех предыдущих шагов:
 

--- a/bootstrap/scripts/mini-preflight.sh
+++ b/bootstrap/scripts/mini-preflight.sh
@@ -81,6 +81,14 @@ else
 fi
 
 echo ""
+echo "SSH keepalive:"
+if grep -rq '^[[:space:]]*ClientAliveInterval[[:space:]]' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/ 2>/dev/null; then
+    ok "sshd ClientAliveInterval configured (SSH drops during advisor calls prevented)"
+else
+    warn "sshd ClientAliveInterval не задан — SSH может обрываться на длинных advisor-вызовах; проверь шаг 19 в mac-mini-2018.md (и ClientAliveCountMax)"
+fi
+
+echo ""
 echo "Claude Code:"
 if command -v claude >/dev/null 2>&1; then
     ok "claude: $(claude --version 2>/dev/null | head -1)"


### PR DESCRIPTION
## Summary

- Adds step 19 to `bootstrap/hardware/mac-mini-2018.md`: `ClientAliveInterval 60` / `ClientAliveCountMax 3` on mini's sshd, `ServerAliveInterval 60` / `CountMax 3` on MacBook `~/.ssh/config`
- Adds SSH keepalive section to `mini-preflight.sh`: `grep -rq` across `/etc/ssh/sshd_config` + `/etc/ssh/sshd_config.d/` (handles Sequoia `Include` directive); warns if unset
- Detection window: 3 minutes. Verification: `sudo sshd -T | grep -i clientalive`

Closes #15

## DoD checklist

- [x] ADR: not required (no architectural triggers per `docs/principles.md`)
- [x] Domain docs: not affected
- [x] Tests: no automated tests — planned explicitly; manual integration steps in `plan.md` §5
- [x] `/review` (Claude): approved, no BLOCKs
- [x] `/codex-review`: **SKIPPED** — Plus-OAuth timeout (exit 124); `type:deferred-review` issue opened. DoD OR clause satisfied.
- [x] Review disagreements: S2 (ok-message language) skipped intentionally — project migrating to EN-only artifacts (see #38)
- [x] Human self-review: pending
- [x] Security scans: N/A (no code dependencies added)
- [x] Docs: runbook updated in-place (mac-mini-2018.md step 19)
- [x] CI: no required jobs for doc/script changes
- [x] Conventional commit + governance hook: passed
- [x] PR references issue: `Closes #15`

## Notes

**S2 skip reason:** `/review` flagged the `warn` message in `mini-preflight.sh` as Russian while the `ok` message is English. Operator confirmed project is migrating to EN-only artifacts — mixed state is acceptable during migration. Tracked in #38.

**`--install` required before testing preflight on mini:** Changes live in `bootstrap/scripts/`; preflight runs from `~/.claude/scripts/`. Run `./bootstrap/universal-setup.sh --install` on mini before testing step 3 of the integration plan.

**Root cause note:** WireGuard (Tailscale) has a built-in 25s keepalive, so pure NAT conntrack timeout is unlikely the root cause. More probable: Tailscale relay fallback or MacBook Wi-Fi/power-nap. App-level keepalives fix all these cases. If drops persist post-fix, investigate `tailscale status` relay transitions before reducing interval below 60s.