### PR TITLE
fix(bootstrap): sharpen drift hint messages in universal-setup.sh

### DIFF
--- a/bootstrap/universal-setup.sh
+++ b/bootstrap/universal-setup.sh
@@ -436,14 +436,14 @@ fi
 echo ""
 log "Done ($MODE mode)"
 if [ "$DRIFT" -gt 0 ] && [ "$MODE" = "install" ]; then
-    warn "drift: $DRIFT file(s) differ from repo source — re-run with --force to overwrite."
+    warn "drift: $DRIFT file(s) differ from repo source — re-run with --force to apply: ./bootstrap/universal-setup.sh --install --force"
     exit 4
 fi
 if [ "$MODE" = "check" ]; then
     if [ "$DRIFT" -eq 0 ]; then
         ok "no drift — idempotent ✓"
     else
-        warn "drift: $DRIFT item(s) differ — run '--install' to see diffs, '--install --force' to overwrite."
+        warn "drift: $DRIFT item(s) differ — run '--install' to see diffs, '--install --force' to apply."
     fi
 else
     echo "  Перезапусти shell или выполни: source ~/.zshrc"

--- a/docs/decisions/0010-installer-drift-behavior.md
+++ b/docs/decisions/0010-installer-drift-behavior.md
@@ -1,6 +1,6 @@
 # 0010. Abort installer on drift unless --force is passed
 
-* Status: proposed
+* Status: accepted
 * Date: 2026-04-23
 * Deciders: venil
 * Tags: installer, contract, idempotency, safety
@@ -168,6 +168,8 @@ Option C отвергается как расширение публичного
 Интеграционный тест добавляется в тот же `baseline-verification` CI job.
 Перед merge'ем проверить, что CI job трактует любой non-zero exit как failure
 (иначе exit 4 проигнорируется и smoke-тест драйверит ложный green).
+
+**Note (2026-04-24):** `baseline-verification` CI job does not yet exist in `.github/workflows/`. Confirmation items 1–4 above are verified locally only. Creating the CI job is tracked separately.
 
 ## Re-visit Trigger
 


### PR DESCRIPTION
## Summary

- Exit-4 hint now prints the exact runnable command (`./bootstrap/universal-setup.sh --install --force`) instead of vague "re-run with --force to overwrite"
- `--check` drift hint updated from "to overwrite" to "to apply" for consistency
- Flips ADR-0010 status from `proposed` → `accepted` (Option B has been live since PR #30)
- Adds honest note in ADR-0010 Confirmation section that `baseline-verification` CI job does not yet exist in `.github/workflows/`; confirmation items 1–4 are locally verified only

## Closes

Closes #25

## Implements

Implements docs/decisions/0010-installer-drift-behavior.md

## Test plan

- [ ] `--install` on a clean `~/.claude/` → exit 0
- [ ] Modify one file in `~/.claude/agents/` → `--install` → exit 4, diff shown, file NOT overwritten, new hint message visible
- [ ] `--install --force` after drift → exit 0, file overwritten
- [ ] `--check` on drifted state → shows drift with updated "to apply" wording
- [ ] `--install --force` twice → exit 0 both times (idempotent)

## DoD

- [x] ADR-0010 flipped to accepted (no new ADR needed — existing decision formalised)
- [x] `/review` (Claude) — no BLOCKs
- [ ] `/codex-review` — SKIPPED (Plus-OAuth timeout); deferred-review issue opened — **DoD criterion "two-voice review" not satisfied; recorded here as acknowledged gap**
- [ ] Human self-review
- [x] CI green on required jobs
- [x] Conventional Commits; governance-hook passed
- [x] PR body references issue (`Closes #25`) and ADR (`Implements docs/decisions/0010-installer-drift-behavior.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)