### PR TITLE
fix(hooks): sanitize double-quotes in json_deny reason

### DIFF
--- a/bootstrap/hooks/pre-commit-governance.sh
+++ b/bootstrap/hooks/pre-commit-governance.sh
@@ -19,7 +19,7 @@ set -uo pipefail
 # --- Helpers ---
 
 json_deny() {
-    local reason="$1"
+    local reason="${1//\"/\\\"}"
     cat <<JSON
 {
   "hookSpecificOutput": {

--- a/bootstrap/scripts/test-governance-hook.sh
+++ b/bootstrap/scripts/test-governance-hook.sh
@@ -116,6 +116,13 @@ assert_allowed() {
 
 echo "Bad commits (must be blocked with exit 2):"
 
+# No -m flag — exercises quoted-reason JSON path (issue #20 regression guard)
+# Before fix: json_deny emits malformed JSON → jq parse fails → reason="" → test fails
+assert_blocked \
+    "no -m flag — deny reason is valid JSON" \
+    'git commit' \
+    "without -m"
+
 # Rule 1: no Conventional Commits prefix
 assert_blocked \
     "no CC prefix" \


### PR DESCRIPTION
## Summary

- `json_deny()` interpolated `$reason` raw into the heredoc JSON — any caller passing a string with literal `"` characters produced malformed JSON that Claude Code's hook infrastructure failed to parse
- Fix: `local reason="${1//\"/\\\"}"` at function entry covers all 5 callers (lines 75, 98, 106, 123, 168) without touching call sites
- Adds regression guard in `test-governance-hook.sh`: the no-`-m`-flag case now verifies the deny response is valid JSON via `jq` parse; confirmed to fail on unfixed hook

**Remaining limitation:** backslash and control characters in `$msg`/`$branch` remain unsafe — tracked as follow-up (Option C: `jq --arg`).

## Closes

Closes #20

## Test plan

- [x] `bash bootstrap/scripts/test-governance-hook.sh` — all 7 tests pass including new regression guard
- [x] New test confirmed to catch the bug on unfixed hook ("exit 2 but deny reason is empty")
- [ ] Human self-review

## DoD

- [x] `/review` (Claude) — no BLOCKs
- [ ] `/codex-review` — SKIPPED (Plus-OAuth timeout × 2); deferred-review issue opened — **"two-voice review" DoD criterion not satisfied; acknowledged gap**
- [ ] Human self-review
- [x] CI green on required jobs
- [x] Conventional Commits; governance-hook passed
- [x] PR body references issue (`Closes #20`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)