### PR TITLE
fix(bootstrap): augment PATH for subshell invocations

### DIFF
--- a/bootstrap/universal-setup.sh
+++ b/bootstrap/universal-setup.sh
@@ -26,6 +26,11 @@
 
 set -uo pipefail
 
+# Augment PATH for subshell invocations (e.g. Claude Code slash commands) where
+# ~/.zshrc has not been sourced. Covers mise/uv user installs, Intel Homebrew,
+# and Apple Silicon Homebrew. Idempotent if dirs are already present.
+export PATH="$HOME/.local/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"
+
 # --- Colors & helpers ---
 RED='\033[0;31m'; YEL='\033[0;33m'; GRN='\033[0;32m'; CYN='\033[0;36m'; NC='\033[0m'
 log()  { printf "${CYN}[setup]${NC} %s\n" "$*"; }


### PR DESCRIPTION
## Summary

- `universal-setup.sh` exits 2 when run from Claude Code slash commands because the subshell PATH is minimal and doesn't include `$HOME/.local/bin` (mise-managed `claude`) or `/usr/local/bin` (Homebrew `gh`)
- Fix: one `export PATH=` line immediately after `set -uo pipefail`, covering Intel Homebrew, Apple Silicon Homebrew, and user-level tool managers (mise/uv/pipx)
- Issue #27 body filled in with repro steps + AC; `needs-repro` and `needs-ac` labels removed

## Repro (confirmed before/after)

```bash
# Before fix: exit 2 — claude not found
# After fix:  exit 0 — all tools found
env -i HOME="$HOME" PATH="/usr/bin:/bin:/usr/sbin:/sbin" bash ./bootstrap/universal-setup.sh --check
```

## Closes

Closes #27

## Test plan

- [x] `env -i` repro exits 2 pre-fix, exits 0 post-fix
- [x] Normal login-shell invocation still exits 0
- [x] `shellcheck bootstrap/universal-setup.sh` exits 0 (ADR-0012 invariant)
- [ ] Apple Silicon path (`/opt/homebrew/bin`) — cannot verify locally (Intel machine); included per documented Homebrew layout

## DoD

- [x] `/review` (Claude) — no findings
- [ ] `/codex-review` — SKIPPED (Plus-OAuth timeout); deferred-review issue opened — **"two-voice review" DoD criterion not satisfied; acknowledged gap**
- [ ] Human self-review
- [x] CI green on required jobs
- [x] Conventional Commits; governance-hook passed
- [x] PR body references issue (`Closes #27`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)