### PR TITLE
feat(domain): populate claude-mini-pipeline bounded context

### DIFF
--- a/docs/domain/overview.md
+++ b/docs/domain/overview.md
@@ -1,0 +1,142 @@
+# Bounded Context: claude-mini-pipeline
+
+**Version:** 2026-04-24
+**Status:** draft — pending domain-reviewer approval
+
+## Purpose
+
+This BC owns the workflow choreography for AI-assisted software development: pipeline stages, agent invocation, governance enforcement, ADR discipline, and the Definition of Done. It does NOT own the source code of projects where claude-mini is installed, Claude Code internals, or Anthropic model internals.
+
+---
+
+## Actors
+
+| Actor | Role | Authority |
+|---|---|---|
+| **Operator** | Human running Claude Code; sole final decision-maker and author of production code | Full write, merge, approve |
+| **Main Loop** (Sonnet) | Orchestrates all pipeline actions under operator direction | Write authority within repo |
+| **Advisor** (Opus) | Consulted via `advisor()` before substantive work and before declaring done; two calls minimum on nontrivial tasks | Read-only; returns critique, not edits |
+| **Read-only Critic** (subagent) | `adr-reviewer`, `domain-reviewer`, `security-reviewer`, `backlog-groomer` — evaluate artifacts, return markdown reports | Read-only; never writes to filesystem or mutates GitHub |
+| **Author-gateway** (subagent) | `domain-researcher`, `solutions-architect` — invoke write-capable skills for docs artifacts only | Limited write via skill (docs only, not production code) |
+| **Skill** | Slash-command (`/plan`, `/adr`, `/implement`, `/review`, `/feature`, etc.) executing under main-loop authority | Main-loop authority |
+| **GitHub MCP** | MCP server invocable from inside the pipeline; ACL layer over GitHub platform | Pipeline-scoped GitHub API calls |
+| **Codex CLI** | Second voice in two-voice review; accessed via ChatGPT Plus device-auth OAuth | Read-only output (review text) |
+
+---
+
+## Commands and Domain Events
+
+Commands are what mutate the `FeatureRun` aggregate. Each command emits one or more events.
+
+### FeatureRun commands (lifecycle)
+
+| Command | Emits |
+|---|---|
+| `StartFeaturePipeline(issue)` | `FeaturePipelineStarted` |
+| `DraftPlan` | `PlanDrafted` |
+| `InvokeAdvisor` | `AdvisorInvoked`, `AdvisorReturned` |
+| `DraftADR` | `ADRDrafted` |
+| `RequestADRReview` | `ADRReviewRequested` |
+| `StartImplementation` | `ImplementationStarted` |
+| `ModifyDomainDocs` | `DomainDocsChanged` |
+| `RequestReview` | `ReviewRequested` |
+| `RequestCodexReview` | `CodexReviewRequested` \| `CodexReviewSkipped` |
+| `RecordTwoVoiceResult(agreed\|disagreed)` | `TwoVoiceDisagreed` \| `TwoVoiceReconciled` \| `DeferredReviewIssueCreated` |
+| `RequestSecurityReview` | `SecurityReviewRequested` |
+| `AttemptCommit` | `CommitAttempted` → `GovernanceBlocked` \| `GovernanceApproved` |
+| `CreatePR` | `PRCreated` |
+| `DeclareDoDSatisfied` | `DoDSatisfied` |
+| `MergeToMain` | `MergedToMain` |
+| `MergeADR` | `ADRMerged` |
+
+### Out-of-band commands (not part of FeatureRun)
+
+| Command | Emits | Notes |
+|---|---|---|
+| `PromoteTaskToIssue` | `TaskPromotedToIssue` | Pre-pipeline; no FeatureRun yet |
+| `RunBacklogGroomer` | `BacklogGroomed` | Weekly cron; independent aggregate |
+
+---
+
+## Boundary
+
+**In scope:**
+- Feature pipeline choreography (stages, ordering, gates)
+- Agent invocation rules (who, when, conditions)
+- Governance hooks (commit-msg enforcement)
+- ADR lifecycle (draft → review → merge)
+- Domain model lifecycle (this BC maintains its own docs/domain/)
+- Definition of Done enforcement
+- Advisor policy (when to invoke, minimum count)
+- Two-voice review protocol
+- Fan-out rules (what is and isn't parallelizable)
+- Issue-first discipline
+
+**Out of scope:**
+- Source code of downstream projects where claude-mini is installed
+- Claude Code engine internals (tool dispatch, context window management)
+- GitHub platform internals (Actions runner mechanics, PR merge algorithms)
+- Anthropic API (abstracted by Claude Code; pipeline never calls it directly)
+- RTK proxy (infrastructure below the BC line)
+
+**Terms that change meaning at the boundary:**
+
+| Term | Inside this BC | Outside |
+|---|---|---|
+| `review` | `/review` + `/codex-review` two-voice gate | GitHub web UI PR review |
+| `issue` | Backlog item with `#NNN` reference | "A problem" (generic English) |
+| `agent` | Claude Code subagent: read-only critic or author-gateway (ADR 0007) | Any AI agent |
+| `pipeline` | This BC's canonical feature pipeline | CI/CD pipeline |
+| `skill` | Slash-command running under main-loop authority | Generic capability |
+
+---
+
+## Aggregate Root
+
+**`FeatureRun`** — one complete invocation of `/feature <issue-number>`.
+
+Invariants:
+- Exactly one issue reference (`Closes #NNN`) per run
+- DoD checklist is monotonic: checkboxes flip false → true only, never reversed within a run
+- Two-voice state machine: `{pending → agreed | disagreed → reconciled | disagreed → deferred}`
+- `advisor()` called ≥ 2 times when task is nontrivial (per `docs/principles.md`)
+
+**Note:** `BacklogGroomed` belongs to a separate out-of-band aggregate (weekly backlog run). It is not part of `FeatureRun`.
+
+---
+
+## Policies
+
+| Trigger event/condition | Policy |
+|---|---|
+| `DomainDocsChanged` | Invoke `domain-reviewer` |
+| `ADRDrafted` | Invoke `adr-reviewer` |
+| PR contains prod-bound change | Invoke `security-reviewer` inside `/review` phase |
+| `TwoVoiceDisagreed` and unresolved at PR time | Create deferred-review issue (`type:deferred-review`) |
+| `CommitAttempted` without issue-ref | `GovernanceBlocked` |
+| `CommitAttempted` on ADR-significant change without ADR-link | `GovernanceBlocked` |
+
+---
+
+## Context Map
+
+| External BC | DDD Pattern | Notes |
+|---|---|---|
+| **GitHub platform** (Issues, PRs, Projects, Actions) | Customer/Supplier + Open Host Service | Pipeline is customer. ACL via GitHub MCP server + `gh` CLI. Translates GitHub model into domain terms (issue-ref, PR body contract). |
+| **ChatGPT Plus / Codex CLI** | Conformist | Pipeline takes device-auth OAuth output as-is; no translation layer. Corporate repo restriction is an operator access-gate, not a DDD pattern. |
+| **Git hook system** | Customer/Supplier | `.git/hooks/` is the physical installation boundary per Principle 5. Pipeline supplies the hook; git is the consumer. |
+| **Anthropic API** | Separate Ways | Claude Code abstracts it; this BC never integrates with Anthropic API directly. Both systems operate independently from the domain's perspective. |
+
+---
+
+## Red Hotspots
+
+Unresolved questions left explicit — not papered over:
+
+1. **`domain-researcher` has no pipeline stage trigger.** ADR 0013 names this gap. Correct trigger is "docs/domain/ missing or stale", not "greenfield only". Resolution requires ADR 0014. Tracked in issue #60.
+2. **24 events may indicate God BC.** `BacklogGroomed` and the governance sub-flow (`CommitAttempted` / `GovernanceBlocked` / `GovernanceApproved`) are candidates for a separate BC. Not split here — decision deferred until the aggregate proves unwieldy in practice.
+3. **Fan-out boundary is human judgement.** "Embarrassingly parallel" (ADR 0002) is defined by examples, not a mechanical rule. No automation path identified.
+4. **Codex skip ≠ Codex disapproval.** DoD requires a `deferred-review` issue on skip, but the gate between skip and fail is operator judgement. Not modelled formally.
+5. **Nontrivial-task criterion for advisor-×-2** is enumerated in `docs/principles.md` but requires judgement at the margin.
+6. **Skill vs agent distinction can drift.** ADR 0007 is normative but subtle; new contributors may conflate them.
+7. **ADR 0013 cited in domain policies is `proposed`, not `accepted`.** Policy `DomainDocsChanged → domain-reviewer` is contingent on ADR 0013 being accepted. This doc should be updated once ADR 0013 status changes.

--- a/docs/domain/overview.md
+++ b/docs/domain/overview.md
@@ -1,7 +1,7 @@
 # Bounded Context: claude-mini-pipeline
 
 **Version:** 2026-04-24
-**Status:** draft — pending domain-reviewer approval
+**Status:** draft — approved by domain-reviewer; pending PR merge
 
 ## Purpose
 

--- a/docs/domain/vocabulary.md
+++ b/docs/domain/vocabulary.md
@@ -1,7 +1,7 @@
 # Ubiquitous Language — claude-mini-pipeline
 
 **Version:** 2026-04-24
-**Status:** draft — pending domain-reviewer approval
+**Status:** draft — approved by domain-reviewer; pending PR merge
 
 Terms are listed alphabetically. Each entry: one-sentence definition, then discriminating note where the term is easily confused.
 

--- a/docs/domain/vocabulary.md
+++ b/docs/domain/vocabulary.md
@@ -1,0 +1,150 @@
+# Ubiquitous Language — claude-mini-pipeline
+
+**Version:** 2026-04-24
+**Status:** draft — pending domain-reviewer approval
+
+Terms are listed alphabetically. Each entry: one-sentence definition, then discriminating note where the term is easily confused.
+
+---
+
+## ADR (Architecturally Significant Decision Record)
+
+A MADR 4.0 document in `docs/decisions/NNNN-*.md` recording a decision that meets at least one trigger in `docs/principles.md#что-значит-архитектурно-значимо`. Required before implementation; merged via canonical pipeline.
+
+*Discriminating note:* a plan is not an ADR. If no trigger fires, use `/plan`, not `/adr`.
+
+---
+
+## Advisor
+
+The Opus model instance invoked via `advisor()` to critique plans and review completed work. Always called at least twice on nontrivial tasks: before starting substantive work and before declaring done. Returns critique only — never edits files.
+
+*Discriminating note:* the advisor is not part of the two-voice review. Two-voice = Claude `/review` + Codex `/codex-review`. Advisor = operator's senior consultant.
+
+---
+
+## Agent
+
+A Claude Code subagent with a defined role and constrained toolset. Two subtypes per ADR 0007:
+- **Read-only critic** — reads and evaluates, returns markdown report, never writes: `adr-reviewer`, `domain-reviewer`, `security-reviewer`, `backlog-groomer`.
+- **Author-gateway** — invokes a write-capable skill for docs artifacts only: `domain-researcher`, `solutions-architect`.
+
+*Discriminating note:* "agent" in generic AI parlance means any AI agent. Inside this BC it means specifically a Claude Code subagent with the constraints above. See `docs/decisions/0007-read-only-critic-agents.md`.
+
+---
+
+## Author-gateway
+
+An agent subtype that can invoke a write-capable skill to produce documentation artifacts (`docs/decisions/`, `docs/domain/`). Does not write production code. Does not edit existing files. Examples: `domain-researcher` (→ `domain-discovery` skill), `solutions-architect` (→ `adr-author` skill). See ADR 0007.
+
+---
+
+## Canonical Pipeline
+
+The documented sequence in `CLAUDE.md:27-34`: `task-to-issue → plan → adr (if needed) → implement → review → codex-review → governance → PR`. The single authoritative path for feature work. Deviations require justification. Orchestrated by `/feature`.
+
+---
+
+## Definition of Done (DoD)
+
+The checklist in `docs/principles.md#definition-of-done` that every change must satisfy before merge. Includes: ADR merged (if significant), domain docs updated (if BC changed), reviews passed, CI green, governance hook passed, PR body cross-references.
+
+*Discriminating note:* DoD is the merge gate, not a style guide. Unchecked boxes block merge.
+
+---
+
+## Deferred Review
+
+The state in which the second voice of two-voice review could not complete. Represented as a GitHub issue of type `type:deferred-review` (the artifact). Created when `/codex-review` is skipped (e.g., Plus OAuth quota exhausted, corporate repo gate). Satisfies the DoD graceful-degradation clause. Does not substitute for a passing review.
+
+*Naming note:* "Deferred Review" is the concept/state. "deferred-review issue" is the GitHub artifact. `DeferredReviewIssueCreated` is the domain event. Three forms, one concept.
+
+---
+
+## Fan-out
+
+Spawning multiple parallel agents or sub-tasks. Forbidden for feature work (ADR 0002). Permitted only for embarrassingly-parallel tasks: symbol renames across many files, import migrations, test templating from schema.
+
+*Discriminating note:* embarrassingly-parallel is defined by examples, not a mechanical rule. Operator judgement required at the margin.
+
+---
+
+## Feature Pipeline
+
+The canonical multi-stage workflow for delivering a change: issue → plan → (ADR) → implement → review → codex-review → governance → PR. Orchestrated by the `/feature` skill. Synonymous with Canonical Pipeline.
+
+---
+
+## Feature Run
+
+One complete execution of `/feature <issue-number>`. The aggregate root of this BC. Invariants: single issue reference, monotonic DoD checklist, two-voice state machine, advisor called ≥ 2 times on nontrivial work.
+
+---
+
+## Governance Hook
+
+The `pre-commit-governance.sh` shell hook installed at `.git/hooks/commit-msg`. Enforces Conventional Commits prefix and issue-ref (`#NNN`) on every commit. For ADR-significant changes, also enforces `Implements docs/decisions/NNNN-*.md`. Blocks commit if rules fail (`GovernanceBlocked` event).
+
+---
+
+## Governance-blocked Commit
+
+A commit rejected by the governance hook. Not a failure state — it is the hook doing its job. Operator fixes the commit message and retries.
+
+---
+
+## Issue-first
+
+The rule that any task longer than one session must have a GitHub issue before work starts. Enforced by the governance hook (commit-msg requires `#NNN`). Issues created via `/task-to-issue`.
+
+---
+
+## Main Loop
+
+The Sonnet model instance that orchestrates all pipeline actions within a session. Has write authority over files and GitHub (within permissions). Distinct from the advisor (read-only) and agents (subagents with constrained toolsets).
+
+---
+
+## Operator
+
+The human running Claude Code. Sole author of production code. Final decision-maker on all architectural choices. Claude is a "soul-crushing partner, not an expert" (Principle 2) — the operator is the expert.
+
+---
+
+## Pipeline Stage
+
+A named step within the Feature Pipeline: `/plan`, `/adr`, `/implement`, `/review`, `/codex-review`, governance commit, `gh pr create`. Stages are ordered and gated; skipping a stage requires explicit justification.
+
+---
+
+## Read-only Critic
+
+An agent subtype that reads artifacts and returns a markdown report. Never writes to the filesystem. Never mutates GitHub. Examples: `adr-reviewer`, `domain-reviewer`, `security-reviewer`, `backlog-groomer`. See ADR 0007.
+
+---
+
+## Red Hotspot
+
+An unresolved question or known invariant violation that the domain docs explicitly leave open. Flagged honestly rather than papered over. Current hotspots: see `overview.md#red-hotspots`.
+
+---
+
+## Skill
+
+A slash-command (`/plan`, `/adr`, `/implement`, `/review`, `/feature`, etc.) that executes under main-loop authority. Has full write capability (subject to permissions). Distinct from agents, which are subagents with constrained toolsets.
+
+*Discriminating note:* a skill is not an agent. Skills run inside the main loop. Agents are separate Claude Code subagents. This distinction is normative in ADR 0007 and subtle in practice.
+
+---
+
+## Two-voice Review
+
+The gating mechanism combining `/review` (Claude main loop) and `/codex-review` (Codex CLI). Both must pass or their disagreement must be reconciled in the PR thread. If Codex is unavailable, a deferred-review issue is created.
+
+*Discriminating note:* two-voice = Claude vs Codex. Advisor is not part of two-voice.
+
+---
+
+## Ubiquitous Language
+
+The shared vocabulary of this bounded context. Terms here are used with their definitions above in all ADRs, issues, PR descriptions, runbooks, and conversations. Drift from these definitions is detected by `domain-reviewer`.


### PR DESCRIPTION
## Summary

- Adds `docs/domain/overview.md`: Actors, Commands, Domain Events, Boundary, Aggregate Root (`FeatureRun`), Policies, Context Map, Red Hotspots
- Adds `docs/domain/vocabulary.md`: 19 Ubiquitous Language terms with discriminating definitions
- Passed two rounds of `domain-reviewer` (BLOCK → APPROVE)

## Key decisions captured

- `FeatureRun` as aggregate root; `BacklogGroomed` explicitly out-of-band
- 5 boundary terms defined (review, issue, agent, pipeline, skill)
- Context map: GitHub=Customer/Supplier, Codex=Conformist, Anthropic API=Separate Ways
- 7 red hotspots including `domain-researcher` trigger gap (→ ADR 0014) and ADR 0013 proposed-status dependency

Closes #11
Implements docs/decisions/0013-agent-invocation-wiring.md