### PR TITLE
feat(review): surface domain invariants to /review and adr-reviewer (#71)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,8 @@ Read-only критики. Вызов: `@agent-<name>`.
 
 | Агент | Когда звать |
 |---|---|
-| `adr-reviewer` | После черновика ADR — проверит полноту секций MADR 4.0 |
-| `domain-reviewer` | После правки `docs/domain/` — ловит vocabulary drift, нарушения BC |
+| `adr-reviewer` | После черновика ADR — проверит полноту секций MADR 4.0 и конфликты с инвариантами `FeatureRun` |
+| `domain-reviewer` | После правки `docs/domain/` — ловит vocabulary drift, нарушения BC, нарушения инвариантов `FeatureRun` в текущем диффе |
 | `domain-researcher` | Когда `docs/domain/` пуст или устарел — перед `/plan` (триггер: missing-or-stale, не только greenfield) |
 | `solutions-architect` | Значимый технический выбор — library, integration contract, данные |
 | `backlog-groomer` | **Out-of-band by design.** Раз в неделю — предлагает triage, сам не мутирует. Не входит в feature pipeline. |

--- a/bootstrap/agents/adr-reviewer.md
+++ b/bootstrap/agents/adr-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: adr-reviewer
-description: Read-only critic for MADR 4.0 ADRs. Invoke after drafting `docs/decisions/NNNN-*.md` to check section completeness, Considered Options depth, and Bad/Good consequence balance. Does NOT propose alternatives or write files.
+description: Read-only critic for MADR 4.0 ADRs. Invoke after drafting `docs/decisions/NNNN-*.md` to check section completeness, Considered Options depth, Bad/Good consequence balance, and conflicts with declared `FeatureRun` invariants. Does NOT propose alternatives or write files.
 tools: Read, Glob, Grep
 model: sonnet
 color: blue
@@ -13,7 +13,7 @@ You are an ADR reviewer in the MADR 4.0 tradition. You read proposed ADR files a
 When invoked:
 
 1. Ask which ADR file to review (path to `docs/decisions/NNNN-*.md`) if not given.
-2. Read the file in full. Read `docs/principles.md` for context on invoked principles.
+2. Read the file in full. Read `docs/principles.md` for context on invoked principles. Read `docs/domain/overview.md` (Aggregate Root and Policies sections) to check whether the proposed decision contradicts any declared `FeatureRun` invariant or Policies row.
 3. Evaluate against severity ladder below.
 4. Return markdown report with findings grouped by severity. Approve only if zero CRITICAL and zero WARNING.
 
@@ -26,6 +26,7 @@ When invoked:
 - **Bad Consequences < Good Consequences** — if Good > Bad, the author is rationalizing. Refuse.
 - **No link to `docs/principles.md`** when ADR invokes a principle (e.g., mentions "least risk", "single author", "knowledge in tools").
 - **No concrete Confirmation mechanism** — "we will monitor" is not concrete; "run `/usage` weekly, threshold 5%" is.
+- **ADR contradicts a declared `FeatureRun` invariant or Policies row** — e.g., proposes skipping advisor calls (violates "advisor ≥ 2 on nontrivial tasks"), removes issue-ref requirement (violates "single issue-ref per run"), or introduces a pipeline branch that bypasses the two-voice state machine. Cross-check against `docs/domain/overview.md` §Aggregate Root and §Policies.
 
 ### WARNING (should resolve)
 

--- a/bootstrap/agents/domain-reviewer.md
+++ b/bootstrap/agents/domain-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: domain-reviewer
-description: Read-only critic for domain documentation in `docs/domain/`. Detects vocabulary drift, bounded context violations, and unclear Ubiquitous Language. Does NOT add terms or rewrite docs.
+description: Read-only critic for domain documentation in `docs/domain/`. Detects vocabulary drift, bounded context violations, unclear Ubiquitous Language, and `FeatureRun` invariant violations in the current diff. Does NOT add terms or rewrite docs.
 tools: Read, Glob, Grep
 model: sonnet
 color: green
@@ -14,12 +14,14 @@ When invoked:
 
 1. Read the domain file(s) in focus and any referenced cross-BC docs.
 2. Read `docs/domain/vocabulary.md` (if exists) to check UL consistency.
-3. Return findings by severity.
+3. Read `docs/domain/overview.md` (Aggregate Root and Policies sections) and cross-check the current diff or doc change against the four `FeatureRun` invariants (single issue-ref per run, monotonic DoD checklist, two-voice state machine, advisor ≥ 2 on nontrivial tasks) and every row of the Policies table. Flag any violation as CRITICAL. If the invocation has no associated diff (e.g., standalone doc review with no pipeline change), state "N/A — no diff to cross-check against invariants" and skip this step.
+4. Return findings by severity.
 
 ## Severity ladder
 
 ### CRITICAL
 
+- **`FeatureRun` invariant or Policies row violation in current diff** — the diff or doc change contradicts a declared invariant (single issue-ref per run, monotonic DoD checklist, two-voice state machine, advisor ≥ 2 on nontrivial tasks) or a Policies table row from `docs/domain/overview.md`. Cite the specific invariant/row and the conflicting change.
 - **Bounded Context boundary not explicit** — no statement of what's in and what's out.
 - **Ubiquitous Language has < 5 terms** defined with business-language definitions.
 - **Cross-BC term conflict unresolved** — same term has different meanings in two BCs without explicit translation/ACL marking.

--- a/bootstrap/commands/review.md
+++ b/bootstrap/commands/review.md
@@ -10,10 +10,11 @@ Diff: !`git diff --cached HEAD 2>/dev/null || git diff HEAD 2>/dev/null || git s
 Plan: @plan.md
 Principles: @docs/principles.md
 ADRs: !`ls docs/decisions/ 2>/dev/null`
+Domain contracts: @docs/domain/overview.md
 
 ## Your task
 
-Review the diff against the plan and principles. Return markdown with sections:
+Review the diff against the plan, principles, and domain contracts. Return markdown with sections:
 
 - **Correctness** — does it do what the plan says?
 - **Security** — obvious red flags (sql/cmd injection, secret leaks, missing auth)?
@@ -21,6 +22,7 @@ Review the diff against the plan and principles. Return markdown with sections:
 - **Style** — consistent with existing codebase patterns?
 - **Tests** — present, meaningful, covering edge cases?
 - **Plan/ADR deviation** — any implicit drift from written artefacts?
+- **Domain invariants** — does the diff violate any `FeatureRun` invariant or contradict a row in the Policies table from `docs/domain/overview.md`? Check: single issue-ref per run, monotonic DoD checklist, two-voice state machine, advisor ≥ 2 on nontrivial tasks. If the diff does not touch pipeline-contract files, state "N/A — diff does not affect pipeline contracts" and move on.
 
 ## Severity convention
 


### PR DESCRIPTION
## Summary

- `bootstrap/commands/review.md`: load `@docs/domain/overview.md` as context; add **Domain invariants** section with explicit cross-check instruction and N/A escape hatch
- `bootstrap/agents/adr-reviewer.md`: extend Protocol Step 2 to read `overview.md`; add CRITICAL ladder entry for ADR-contradicts-invariant; tighten frontmatter description
- `bootstrap/agents/domain-reviewer.md`: add Protocol Step 3 for invariant cross-check; add matching CRITICAL ladder entry; tighten frontmatter description
- `CLAUDE.md`: update agents table rows to reflect new invariant-check capability

All four files land in a single commit per ADR 0015 Confirmation §5 (atomicity requirement).

## Post-merge checklist

- [ ] Run `./bootstrap/universal-setup.sh --install`
- [ ] `diff bootstrap/commands/review.md ~/.claude/commands/review.md` — must be empty
- [ ] `diff bootstrap/agents/adr-reviewer.md ~/.claude/agents/adr-reviewer.md` — must be empty
- [ ] `diff bootstrap/agents/domain-reviewer.md ~/.claude/agents/domain-reviewer.md` — must be empty

## DoD

- [x] ADR 0015 merged (#72) before /implement
- [x] `/review` approved (no BLOCK findings)
- [ ] `/codex-review` — **SKIPPED** (exit 124 timeout); deferred-review issue #74 opened. Two-voice DoD criterion not satisfied; gap recorded here per CLAUDE.md policy.
- [x] `advisor()` called twice (pre-implement + pre-done)
- [x] Conventional Commits + governance hook passed
- [x] `Closes #71` + `Implements docs/decisions/0015-*.md` in commit

Closes #71
Implements docs/decisions/0015-surface-domain-invariants-to-review-and-adr-reviewer.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)