### PR TITLE
fix(review): fast-fail codex startup hang + auth recovery (#42)

### DIFF
--- a/bootstrap/scripts/mini-health.sh
+++ b/bootstrap/scripts/mini-health.sh
@@ -114,10 +114,10 @@ else
     warn "gh auth inactive"
 fi
 if command -v codex >/dev/null 2>&1; then
-    if codex login status 2>/dev/null | grep -qi "ok\|logged"; then
+    if timeout 10 codex login status 2>/dev/null | grep -qi "ok\|logged"; then
         ok "codex auth"
     else
-        warn "codex auth uncertain"
+        warn "codex auth uncertain or startup slow — fix: rm ~/.codex/auth.json && codex login --device-auth"
     fi
 else
     warn "codex not installed"

--- a/bootstrap/scripts/mini-health.sh
+++ b/bootstrap/scripts/mini-health.sh
@@ -114,7 +114,10 @@ else
     warn "gh auth inactive"
 fi
 if command -v codex >/dev/null 2>&1; then
-    if timeout 10 codex login status 2>/dev/null | grep -qi "ok\|logged"; then
+    _tc=$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || echo "")
+    if [ -n "$_tc" ] && "$_tc" 10 codex login status 2>/dev/null | grep -qi "ok\|logged"; then
+        ok "codex auth"
+    elif [ -z "$_tc" ] && codex login status 2>/dev/null | grep -qi "ok\|logged"; then
         ok "codex auth"
     else
         warn "codex auth uncertain or startup slow — fix: rm ~/.codex/auth.json && codex login --device-auth"

--- a/bootstrap/scripts/mini-preflight.sh
+++ b/bootstrap/scripts/mini-preflight.sh
@@ -45,10 +45,10 @@ else
 fi
 
 if command -v codex >/dev/null 2>&1; then
-    if codex login status 2>/dev/null | grep -qi "logged in\|authenticated\|ok"; then
+    if timeout 10 codex login status 2>/dev/null | grep -qi "logged in\|authenticated\|ok"; then
         ok "codex login активен"
     else
-        warn "codex login статус неясен — проверь: codex login status"
+        warn "codex login статус неясен или startup завис — fix: rm ~/.codex/auth.json && codex login --device-auth"
     fi
 else
     warn "codex CLI не установлен (opt-in; нужен для /codex-review)"

--- a/bootstrap/scripts/mini-preflight.sh
+++ b/bootstrap/scripts/mini-preflight.sh
@@ -45,7 +45,10 @@ else
 fi
 
 if command -v codex >/dev/null 2>&1; then
-    if timeout 10 codex login status 2>/dev/null | grep -qi "logged in\|authenticated\|ok"; then
+    _tc=$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || echo "")
+    if [ -n "$_tc" ] && "$_tc" 10 codex login status 2>/dev/null | grep -qi "logged in\|authenticated\|ok"; then
+        ok "codex login активен"
+    elif [ -z "$_tc" ] && codex login status 2>/dev/null | grep -qi "logged in\|authenticated\|ok"; then
         ok "codex login активен"
     else
         warn "codex login статус неясен или startup завис — fix: rm ~/.codex/auth.json && codex login --device-auth"

--- a/bootstrap/scripts/review-codex.sh
+++ b/bootstrap/scripts/review-codex.sh
@@ -24,16 +24,17 @@ if ! command -v codex >/dev/null 2>&1; then
     exit 0
 fi
 
-if ! command -v timeout >/dev/null 2>&1; then
+TIMEOUT_BIN=$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || echo "")
+if [ -z "$TIMEOUT_BIN" ]; then
     echo "# /codex-review"
     echo ""
-    echo "SKIPPED: 'timeout' command not found. macOS: brew install coreutils"
+    echo "SKIPPED: 'timeout'/'gtimeout' not found. macOS: brew install coreutils (add \$(brew --prefix)/opt/coreutils/libexec/gnubin to PATH)"
     exit 0
 fi
 
 # Fast startup check — codex hangs on startup when Plus OAuth token is stale.
 # Fail in 10s instead of waiting CODEX_TIMEOUT seconds.
-timeout 10 codex --version >/dev/null 2>&1
+"$TIMEOUT_BIN" 10 codex --version >/dev/null 2>&1
 startup_exit=$?
 if [ "$startup_exit" -ne 0 ]; then
     if [ "$startup_exit" -eq 124 ]; then
@@ -133,7 +134,7 @@ tmp_out=$(mktemp)
 tmp_err=$(mktemp)
 trap 'rm -f "$tmp_out" "$tmp_err"' EXIT
 
-timeout "$CODEX_TIMEOUT" codex --model "$CODEX_MODEL" exec "$prompt" \
+"$TIMEOUT_BIN" "$CODEX_TIMEOUT" codex --model "$CODEX_MODEL" exec "$prompt" \
     > "$tmp_out" 2> "$tmp_err"
 exit_code=$?
 

--- a/bootstrap/scripts/review-codex.sh
+++ b/bootstrap/scripts/review-codex.sh
@@ -7,8 +7,8 @@
 #   3. git show HEAD (last commit)
 #   4. Against base branch (main/master) — для review уже коммитнутой ветки
 #
-# На exit 4 (quota) или 124 (timeout) создаёт `type:deferred-review` issue
-# и выходит с маркером SKIPPED — не блокирует pipeline.
+# На startup hang (10s timeout), exit 4 (quota) или 124 (timeout) создаёт
+# `type:deferred-review` issue и выходит с маркером SKIPPED — не блокирует pipeline.
 
 set -uo pipefail
 
@@ -21,6 +21,50 @@ if ! command -v codex >/dev/null 2>&1; then
     echo "# /codex-review"
     echo ""
     echo "SKIPPED: codex CLI не установлен. Install: npm i -g @openai/codex"
+    exit 0
+fi
+
+if ! command -v timeout >/dev/null 2>&1; then
+    echo "# /codex-review"
+    echo ""
+    echo "SKIPPED: 'timeout' command not found. macOS: brew install coreutils"
+    exit 0
+fi
+
+# Fast startup check — codex hangs on startup when Plus OAuth token is stale.
+# Fail in 10s instead of waiting CODEX_TIMEOUT seconds.
+timeout 10 codex --version >/dev/null 2>&1
+startup_exit=$?
+if [ "$startup_exit" -ne 0 ]; then
+    if [ "$startup_exit" -eq 124 ]; then
+        startup_reason="startup hung (10s timeout) — likely stale Plus OAuth token"
+        startup_fix="rm ~/.codex/auth.json && codex login --device-auth"
+    else
+        startup_reason="codex --version failed (exit=$startup_exit) — broken install or bad config"
+        startup_fix="check codex installation: codex --version"
+    fi
+    startup_title="Deferred codex review: $(git rev-parse --short HEAD 2>/dev/null || echo 'unknown')"
+    startup_body=$(cat <<STARTBODY
+Codex CLI не прошёл startup check: $startup_reason
+
+**Fix:** \`$startup_fix\`
+**See:** issue #42 (docs/runbooks/codex-auth-recovery.md)
+
+**Branch:** $(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+**Commit:** $(git rev-parse HEAD 2>/dev/null)
+STARTBODY
+    )
+    echo "# /codex-review" >&2
+    echo "" >&2
+    echo "SKIPPED: codex CLI startup failed — $startup_reason. Fix: $startup_fix" >&2
+    if command -v gh >/dev/null 2>&1; then
+        gh issue create \
+            --title "$startup_title" \
+            --body "$startup_body" \
+            --label "type:deferred-review" >/dev/null 2>&1 || true
+        echo "Opened deferred-review issue." >&2
+    fi
+    echo "SKIPPED"
     exit 0
 fi
 

--- a/docs/runbooks/codex-auth-recovery.md
+++ b/docs/runbooks/codex-auth-recovery.md
@@ -1,0 +1,62 @@
+# Runbook: Codex CLI auth recovery
+
+## Симптомы
+
+- Каждый `/codex-review` завершается с `SKIPPED: codex CLI hung on startup`
+- `deferred-review` issues накапливаются (>1 за сессию)
+- `timeout 2 codex --version` виснет (exit 124), но с большим таймаутом в конечном счёте возвращает `codex-cli X.Y.Z`
+
+## Диагностика
+
+```bash
+# 1. Проверить auth.json — когда последний refresh?
+cat ~/.codex/auth.json | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('auth_mode'), d.get('last_refresh'))"
+
+# 2. Подтвердить, что startup зависает
+timeout 5 codex --version 2>&1; echo "exit=$?"
+# Ожидание при сломанном токене: exit=124 (timeout)
+# Ожидание при здоровом токене: "codex-cli X.Y.Z", exit=0
+```
+
+Если `auth_mode=chatgpt` и `last_refresh` больше недели назад — это и есть причина. Codex CLI пытается обновить токен при каждом старте, запрос зависает на много минут.
+
+## Исправление
+
+```bash
+# Шаг 1: удалить протухший токен
+rm ~/.codex/auth.json
+
+# Шаг 2: пройти device-auth заново (откроется браузер)
+codex login --device-auth
+# Войти в ChatGPT Plus, разрешить доступ
+
+# Шаг 3: убедиться, что startup теперь быстрый
+timeout 5 codex --version
+# Ожидание: "codex-cli X.Y.Z", exit=0 в пределах 2–3 секунд
+```
+
+Если `codex login --device-auth` тоже виснет — вероятно, проблема глубже в бинарнике. Попробуй переустановить через npm (как описано в `bootstrap/hardware/mac-mini-2018.md`, шаг 9):
+
+```bash
+npm i -g @openai/codex
+codex login --device-auth
+```
+
+## После восстановления
+
+После подтверждения работоспособности закрой накопившиеся `type:deferred-review` issues:
+
+```bash
+# Список открытых deferred-review
+gh issue list --label "type:deferred-review" --state open
+
+# Закрыть все разом (подтверди список перед выполнением!)
+gh issue list --label "type:deferred-review" --state open --json number --jq '.[].number' \
+  | xargs -I{} gh issue close {} --comment "Closed after Codex auth recovery (see issue #42)"
+```
+
+## Профилактика
+
+- `mini-preflight.sh` и `mini-health.sh` оба делают `timeout 10 codex login status` — если startup медленный, они покажут warning вместо зависания.
+- `review-codex.sh` делает `timeout 10 codex --version` перед каждым review — если токен протух, скрипт упадёт за 10 секунд (не 120), создаст deferred-review issue с инструкцией по починке.
+- Если deferred-review issues снова начинают накапливаться — сразу проверь `last_refresh` в `~/.codex/auth.json`.

--- a/docs/runbooks/codex-auth-recovery.md
+++ b/docs/runbooks/codex-auth-recovery.md
@@ -10,7 +10,7 @@
 
 ```bash
 # 1. Проверить auth.json — когда последний refresh?
-cat ~/.codex/auth.json | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('auth_mode'), d.get('last_refresh'))"
+python3 -c "import json; d=json.load(open('$HOME/.codex/auth.json')); print(d.get('auth_mode'), d.get('last_refresh'))"
 
 # 2. Подтвердить, что startup зависает
 timeout 5 codex --version 2>&1; echo "exit=$?"


### PR DESCRIPTION
## Summary

- `review-codex.sh`: add 10s startup check (`timeout 10 codex --version`) before diff collection — fails fast instead of waiting 120s when Plus OAuth token is stale; add `timeout`/`gtimeout` fallback (Homebrew coreutils may expose `gtimeout` not `timeout`); differentiate exit 124 (auth hang) vs other errors in deferred-review issue body
- `mini-health.sh`, `mini-preflight.sh`: wrap `codex login status` with `timeout`/`gtimeout` guard to prevent infinite hangs; fall back to unbounded call if neither is available
- `docs/runbooks/codex-auth-recovery.md`: new runbook documenting symptoms, diagnosis, and recovery procedure

## Root cause

Codex CLI (`auth_mode: chatgpt`) silently refreshes the Plus OAuth token on every startup. When the token is stale, this refresh call hangs for many minutes — beyond the 120s `CODEX_TIMEOUT`, causing every `/codex-review` to fail. 12 deferred-review issues accumulated over >1 week. The auth was self-repaired mid-session when a no-timeout background `codex --version` call completed and refreshed the token.

## Two-voice review

- **Claude `/review`**: APPROVE — noted prod-bound path, requested security-reviewer
- **`@agent-security-reviewer`**: APPROVE — no CRITICAL/WARNING; 3 NITs (all pre-existing patterns)
- **Codex `/codex-review`**: BLOCK on missing `timeout` guard in health/preflight (fixed in second commit); SUGGEST on `gtimeout` fallback (fixed); NIT on UUoC in runbook (fixed)
- Two voices agreed on all BLOCK/SUGGEST findings after fixes

## Validation

- Exit-124 path: synthetic slow-codex binary → 10.4s wall time, correct SKIPPED message, `type:deferred-review` issue created ✓
- Happy path: real codex review completed 30s ✓
- No-auth path: existing `*` handler, no spurious issue ✓
- Shellcheck clean on all three scripts ✓

## Known limitations (noted, not fixed in this PR)

- **10s threshold is a first guess** — if fresh-auth startup proves slower in practice, adjust `TIMEOUT_BIN` invocation threshold
- **Duplicate deferred-review issues on repeated runs** — pre-existing behavior in the exit-4/124 handler; not introduced here
- **`grep -qi "ok\|logged"` uses GNU extension `\|`** — pre-existing in both scripts; `-Eqi` migration tracked separately
- **Runbook recovery procedure was not run end-to-end** — the stale token self-repaired mid-session; the runbook describes the correct procedure but was not manually executed

## Post-merge action

Close the 12 open `type:deferred-review` issues per the runbook:
```bash
gh issue list --label "type:deferred-review" --state open --json number --jq '.[].number' \
  | xargs -I{} gh issue close {} --comment "Closed after Codex auth recovery (see issue #42)"
```

Closes #42