### PR TITLE
feat(pipeline): add /qa skill — test + docs gate before /review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .idea/
 *.swp
 /plan.md
+/qa-report.md
 *.bak
 deploy-to-github.sh
 create-backlog.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@
 
 ```
 /task-to-issue (опц.) → /plan <issue> → /adr (если нужно) → /implement
-  → /review → /codex-review → git commit (governance) → gh pr create
+  → /qa → /review → /codex-review → git commit (governance) → gh pr create
 ```
 
 **Conditional agent gates** (вызываются в рамках соответствующей стадии):

--- a/bootstrap/commands/feature.md
+++ b/bootstrap/commands/feature.md
@@ -27,9 +27,12 @@ You are an **orchestrator**, not an executor. You do not run `/plan`, `/implemen
 [ ]    4b. After ADR draft: invoke @agent-adr-reviewer; wait for APPROVE verdict
 [ ]    4c. Merge ADR PR before /implement
 [ ] 5. Run /implement
-[ ] 6. Call advisor() before declaring done (inside /implement)
-[ ]    6a. Only if docs/domain/ was modified during /implement:
+[ ]    5a. (inside /implement) Call advisor() before declaring done — MANDATORY for non-trivial
+[ ]    5b. Only if docs/domain/ was modified during /implement:
 [ ]        invoke @agent-domain-reviewer; wait for APPROVE verdict
+[ ] 6. Run /qa
+[ ]    6a. Review qa-report.md; resolve test gaps or confirm escape hatch accepted
+[ ]    6b. Copy ## QA section from qa-report.md — paste into PR body at step 11
 [ ] 7. Run /review
 [ ]    7a. Only if PR touches prod-bound paths (bootstrap/, .github/workflows/,
 [ ]        .git/hooks/) or is labelled prod-bound:
@@ -37,7 +40,7 @@ You are an **orchestrator**, not an executor. You do not run `/plan`, `/implemen
 [ ] 8. Run /codex-review
 [ ] 9. Resolve findings; decide on disagreements
 [ ] 10. git commit (governance hook checks)
-[ ] 11. gh pr create with "Closes #$ARGUMENTS"
+[ ] 11. gh pr create with "Closes #$ARGUMENTS" — include ## QA section in PR body
 [ ] 12. PR ready for human review
 \`\`\`
 

--- a/bootstrap/commands/implement.md
+++ b/bootstrap/commands/implement.md
@@ -63,9 +63,10 @@ Report to operator:
 
 > Implementation complete. Diff summary: {stats}. Advisor was called {N} times. Next steps:
 >
-> 1. `/review` for Claude review.
-> 2. `/codex-review` for second-voice review.
-> 3. Resolve findings, then commit.
+> 1. `/qa` for test coverage + docs currency check.
+> 2. `/review` for Claude review.
+> 3. `/codex-review` for second-voice review.
+> 4. Resolve findings, then commit.
 
 ## Hard rules
 

--- a/bootstrap/commands/qa.md
+++ b/bootstrap/commands/qa.md
@@ -1,0 +1,79 @@
+---
+description: QA gate — test coverage + docs currency. Fires after /implement, before /review.
+allowed-tools: Read, Glob, Grep, Bash(git diff:*), Bash(git show:*), Bash(git status:*), Bash(git log:*), Bash(find:*), Edit, Write
+model: claude-sonnet-4-6
+---
+
+# /qa
+
+Plan: @plan.md
+Principles: @docs/principles.md
+
+## Your task
+
+Two-checklist pass after `/implement`, before `/review`. Produces `qa-report.md` at the repo root.
+
+### Phase 0 — Carve-out check
+
+Get the list of changed files (`git diff --cached --name-only || git diff HEAD --name-only || git show --name-only --format=`).
+
+Evaluate carve-outs strictly in the order below. **If step 1 matches: write the report, stop immediately — do not evaluate step 2.**
+
+1. **ADR-only** (most specific — evaluate first): every changed file matches `docs/decisions/*.md`. If true → write `qa-report.md` with body `## QA\n\nCarve-out: ADR-only diff. No test or docs check required.` Print it. **Exit.** Do not proceed to step 2 or Phase 1.
+2. **Docs-only**: every changed file matches `*.md`. If true → write `qa-report.md` with body `## QA\n\nCarve-out: docs-only diff. No test or docs check required.` Print it. **Exit.** Do not proceed to Phase 1.
+
+Always record the carve-out reason — never exit silently.
+
+### Phase 1 — Diff triage
+
+Get the full diff: `git diff --cached` (staged) → `git diff HEAD` (working tree) → `git show HEAD` (last commit). Use first non-empty result.
+
+### Phase 2 — Test coverage
+
+For each modified `.sh`, `.py`, or other logic file in the diff:
+
+1. Extract the filename stem (e.g., `review-codex` from `bootstrap/scripts/review-codex.sh`).
+2. Search for a test file: `find . -name "test_${stem}*" -o -name "${stem}_test*" -o -name "*.bats" 2>/dev/null`.
+3. Also check for a `tests/` directory at the repo root.
+4. **If a test file exists**: grep it for the names of changed functions or identifiers. If the changed logic is exercised → mark ✓. If not → note the gap.
+5. **If a gap exists AND a harness exists**: write a minimal smoke test that calls the changed entry point with a representative input and asserts exit code or key output line.
+6. **If no harness exists** (no test files found, no `tests/` dir, no `.bats` files): record the fixed escape-hatch notice verbatim:
+   > `No test harness for [shell scripts]. Escape hatch applied. Add ## QA section to PR body noting this before merge.`
+
+Do not write large test suites. One smoke test per changed entry point is sufficient. If a **new** `.sh` file was created with no corresponding test, additionally note: "New shell script with no harness detected. Consider introducing bats: `brew install bats-core`."
+
+### Phase 3 — Docs currency
+
+For each changed file, identify public contracts that may have documentation:
+
+- **CLI flags / options**: if a script gained or changed a `--flag` or positional arg, check that `--help` output (if any) and relevant runbook in `docs/runbooks/` still match.
+- **Runbook-documented behavior**: search `docs/runbooks/` for the script name; if found, check that the described behavior still matches the diff.
+- **CLAUDE.md references**: if the changed file is named in `CLAUDE.md` canonical pipeline or table, check that the description is still accurate.
+
+For each stale doc found: produce the patch inline (edit the runbook or update the `--help` string). State clearly what was updated.
+
+If no public contracts changed: record `Docs: all contracts current.`
+
+### Phase 4 — QA report
+
+Write `qa-report.md` to the repo root:
+
+```markdown
+## QA
+
+**Tests:** <one of: "all changed paths covered" | list of gaps + what was written | escape hatch notice>
+
+**Docs:** <one of: "all contracts current" | list of updates made>
+```
+
+Print the contents of `qa-report.md` to stdout.
+
+Tell the operator: "Copy the `## QA` section above into the PR body at `gh pr create` time."
+
+## Hard rules
+
+- NEVER exit without writing `qa-report.md`. Every path — carve-out, escape hatch, happy — produces the file.
+- NEVER silently skip. Either report ✓, state the escape hatch verbatim, or state the carve-out reason.
+- This is advisory: you surface findings. Human self-review is the final gate. Do NOT block the pipeline.
+- Carve-outs are file-path based. There is no commit-message carve-out — no commit exists yet at `/qa` time.
+- If `/qa` writes a test or runbook patch, state clearly in the report that Claude authored it, so `/review` can attribute correctly.


### PR DESCRIPTION
## Summary

- Adds `bootstrap/commands/qa.md` — advisory QA gate after `/implement`, before `/review`
- Updates `CLAUDE.md` canonical pipeline: `… → /implement → /qa → /review → …`
- Updates `bootstrap/commands/feature.md` checklist: `/qa` as step 6 with sub-steps for report review and PR-body handoff
- Updates `bootstrap/commands/implement.md` Phase 5 hand-off: directs to `/qa` first
- Adds `/qa-report.md` to `.gitignore` (ephemeral artifact, load-bearing per ADR-0016)

## QA

**Tests:** No test harness for skill files (markdown). Escape hatch applied per ADR-0016: value is concentrated in Phase 3 (docs currency) in a shell-script-only repo. ADR Confirmation criterion (run `/feature 66` end-to-end, verify `qa-report.md` produced) is satisfied by the *next* feature run after merge + install — not this PR. This is the self-application paradox documented in ADR-0016 §Negative consequences.

**Docs:** `implement.md` Phase 5 hand-off updated (Codex SUGGEST); all other referenced docs current.

## Two-voice review

- **Claude `/review`**: APPROVE — no blockers. SUGGEST: invoke `@agent-security-reviewer` (prod-bound path `bootstrap/commands/`) ✓ done.
- **`@agent-security-reviewer`**: APPROVE — NIT on `Bash(find:*)` scope (acknowledged; consistent with peer skills; follow-up issue if hygiene pass wanted).
- **Codex `/codex-review`**: BLOCK (false positive — `qa.md` was untracked in diff; file exists on disk; staged before commit) ✓ resolved. SUGGEST: `implement.md` hand-off ✓ fixed. NITs: acknowledged, no action.

## Related

- Closes #66
- Implements docs/decisions/0016-qa-skill-placement.md (merged via PR #76)

🤖 Generated with [Claude Code](https://claude.com/claude-code)