### PR TITLE
docs(pipeline): add plan↔ADR sync step to runbooks

### DIFF
--- a/docs/runbooks/adr-workflow.md
+++ b/docs/runbooks/adr-workflow.md
@@ -68,6 +68,14 @@ Governance hook не требует issue-ref для `adr:`-коммитов, н
 
 После review другими участниками (если есть) — merge. Пометь issue closed.
 
+### 6. After merge: sync plan.md
+
+After the ADR PR merges, re-read the feature's `plan.md §4` (the gitignored per-feature plan from `/plan`) and update the Chosen approach to match the ADR's Decision Outcome. Make sure your feature branch includes the merged ADR first — run `git rebase main` or `git pull` so the Decision Outcome is readable from disk. Do this before running `/implement`. The plan is written before the ADR interview; the interview can change the mechanism. If `/implement` starts from a stale plan, the discrepancy will likely surface as a `/review` BLOCK or an `advisor()` finding — catching it here is cheaper.
+
+If the pre-implement `advisor()` call reveals a remaining mismatch, fix `plan.md` before writing code.
+
+Evidence of why this step is load-bearing: `docs/runbooks/first-feature-session-log.md` Gap 1.
+
 ## Если ADR не удаётся
 
 Иногда выходит, что принимать решение рано — нет данных, нет примеров реализации. Честный выход: **ADR со статусом "proposed"** и явной секцией "Open questions". Не заставляй себя решать без оснований.

--- a/docs/runbooks/feature-pipeline.md
+++ b/docs/runbooks/feature-pipeline.md
@@ -78,6 +78,8 @@ advisor("Review this plan against codebase. Missing edge cases? ADR violations?"
 
 Дождись merge ADR PR до `/implement`.
 
+If an ADR was authored: after the ADR PR merges, re-read `plan.md §4` — does the Chosen approach match the ADR's Decision Outcome? Update `plan.md` if not, before running `/implement`. The ADR interview can change the mechanism relative to what `plan.md` described before the interview. (Evidence: `docs/runbooks/first-feature-session-log.md` Gap 1.)
+
 ### 5. Implementation
 
 Before running `/implement`, create the feature branch if you haven't already:


### PR DESCRIPTION
## Summary

- `docs/runbooks/adr-workflow.md` gains **step 6** ("After merge: sync plan.md"): after ADR PR merges, re-read `plan.md §4` and update Chosen approach to match ADR's Decision Outcome before `/implement`. Includes clarification to rebase/pull main so the merged ADR is readable on disk.
- `docs/runbooks/feature-pipeline.md` gains a conditional paragraph in step 4 (ADR gate) with the same instruction and a conditional "If an ADR was authored:" guard.
- Both files cite `docs/runbooks/first-feature-session-log.md` Gap 1 as evidence.

Closes #48
Follow-up: #82 (`/feature` skill checklist needs the same step — out of scope for this PR)

## QA

Carve-out: docs-only diff. No test or docs check required.

## Codex review

Two-voice complete (gpt-5.2). Two SUGGESTs applied (branch/working-tree clarification, which plan.md). Three findings addressed inline: terminology disagreement (BLOCK is /review severity, not adr-reviewer's CRITICAL), §4 convention is intentional, duplication deferred to #82.

## Test plan

- [x] Read-back: both new sections at correct positions (step 6 before `## Если ADR не удаётся`; paragraph before `### 5. Implementation`)
- [x] AC walk: all 3 acceptance criteria satisfied
- [x] /review: APPROVE, zero BLOCKs
- [x] /codex-review: no BLOCKs

🤖 Generated with [Claude Code](https://claude.com/claude-code)