### PR TITLE
chore(pipeline): add plan↔ADR sync step to /feature checklist

### DIFF
--- a/bootstrap/commands/feature.md
+++ b/bootstrap/commands/feature.md
@@ -26,6 +26,7 @@ You are an **orchestrator**, not an executor. You do not run `/plan`, `/implemen
 [ ]    4a. If yes: invoke @agent-solutions-architect → /adr
 [ ]    4b. After ADR draft: invoke @agent-adr-reviewer; wait for APPROVE verdict
 [ ]    4c. Merge ADR PR before /implement
+[ ]    4d. If ADR was authored: re-sync `plan.md §4` with merged ADR per `docs/runbooks/adr-workflow.md` step 6
 [ ] 5. Run /implement
 [ ]    5a. (inside /implement) Call advisor() before declaring done — MANDATORY for non-trivial
 [ ]    5b. Only if docs/domain/ was modified during /implement:


### PR DESCRIPTION
## Summary

- `bootstrap/commands/feature.md` gains step **4d** (after 4c): `If ADR was authored: re-sync \`plan.md §4\` with merged ADR per \`docs/runbooks/adr-workflow.md\` step 6`
- Closes the gap from #48: operators running `/feature` directly now see the sync guard inline in the TodoWrite checklist.
- Re-installed via `./bootstrap/universal-setup.sh --install --force`. Note: `--force` also re-deployed `mini-health.sh` (from PR #65, previously staged but not deployed to `~/.claude/scripts/`).

Closes #82
Follow-up from #48

## QA

Carve-out: docs-only diff. No test or docs check required.

## Codex review

Two-voice complete (gpt-5.2). One NIT applied: removed trailing period from 4d to match prevailing checklist style (other sub-items 4a/4b/4c have no trailing period). Two SUGGESTs addressed: referenced artifacts verified (adr-workflow.md step 6 exists at line 71; plan.md §4 stable by convention); "If ADR was authored" ambiguity noted as acceptable — same conditional pattern used throughout the checklist.

## Test plan

- [x] Read-back: 4d at correct position (after 4c, before step 5), single `[ ]` bracket
- [x] Re-install verified: `diff bootstrap/commands/feature.md ~/.claude/commands/feature.md` → IDENTICAL
- [x] AC walk: both criteria satisfied
- [x] /review + @agent-security-reviewer: APPROVE, zero BLOCKs
- [x] /codex-review: no BLOCKs

🤖 Generated with [Claude Code](https://claude.com/claude-code)