### PR TITLE
chore(pipeline): lint plan.md for banned terms before /implement

### DIFF
--- a/bootstrap/commands/implement.md
+++ b/bootstrap/commands/implement.md
@@ -31,6 +31,8 @@ git rev-parse --abbrev-ref HEAD
 
 Note: `bootstrap/commands/implement.md` is installed to `~/.claude/commands/` via `./bootstrap/universal-setup.sh --install`. Changes here require re-install to take effect.
 
+**Banned-terms check:** Read `docs/runbooks/banned-terms.md`. Scan `plan.md` for each scannable pattern (case-insensitive). Occurrences inside quoted spans (surrounded by `"`, `'`, or backtick characters) are exempt — they reference the term, not use it. If an unquoted match is found: **STOP.** Fix `plan.md` before continuing. (If `plan.md` is missing, the Hard Rules existence guard below applies — skip this check.)
+
 1. Read `plan.md` completely. Read every file referenced in it.
 2. Read 3–5 related files for context (neighbouring modules, existing patterns).
 3. Check relevant ADRs (`docs/decisions/`) for constraints.

--- a/docs/runbooks/banned-terms.md
+++ b/docs/runbooks/banned-terms.md
@@ -1,0 +1,31 @@
+# Banned terms
+
+Authoritative list of terms that must not appear in `plan.md`, ADR drafts, agent prompts, PR descriptions, or any other project artifact.
+
+Scan is **case-insensitive**. Each entry lists the banned form, the required substitution, and the rationale.
+
+---
+
+## Employer / company reference
+
+**Scannable pattern:** `employer-owned repositories` (case-insensitive)
+
+**Human-author guidance (no machine pattern — use judgment):**
+- Do not name the employer or company anywhere in artifacts. Use "сторонние репо", "не-pet-проекты", or "third-party repositories" instead.
+
+| Banned form | Use instead |
+|---|---|
+| `employer-owned repositories` | "сторонние репо", "не-pet-проекты", or "third-party repositories" |
+
+---
+
+## How to use this list
+
+In `/implement` Phase 1, before reading any project files:
+
+```
+Read this file. For each banned term above, check plan.md (case-insensitive).
+If any match: STOP. Fix plan.md before continuing.
+```
+
+In the operator checklist (`docs/runbooks/feature-pipeline.md` step 2): verify plan.md is clean before calling advisor or running `/implement`.

--- a/docs/runbooks/feature-pipeline.md
+++ b/docs/runbooks/feature-pipeline.md
@@ -50,6 +50,8 @@ ls docs/domain/  # должен содержать overview.md + vocabulary.md
 
 Создаётся `plan.md` в корне репо. Содержит 6 секций (см. команду). Прочитай плана — если что-то не так, скажи Claude "rewrite section N".
 
+Before running advisor or `/implement`: scan `plan.md` for banned terms (list: `docs/runbooks/banned-terms.md`). Fix any matches before continuing. (Evidence: `docs/runbooks/first-feature-session-log.md` Gap 4.)
+
 ### 3. Advisor critique (MANDATORY для нетривиальной)
 
 ```


### PR DESCRIPTION
## Summary

- `docs/runbooks/banned-terms.md` (new) — authoritative list of banned terms. Currently one scannable pattern: `employer-owned repositories`. Human-author guidance for broader employer/company reference kept separate from machine-scannable patterns.
- `docs/runbooks/feature-pipeline.md` — lint check paragraph at end of step 2, before advisor. Fires before advisor reads plan.md (rationale: banned term polluted advisor context in run #5, not just /implement).
- `bootstrap/commands/implement.md` — `**Banned-terms check:**` block in Phase 1, before step 1. Quoted/backtick spans exempt. Re-installed via `./bootstrap/universal-setup.sh --install --force`.

Closes #79
Evidence: `docs/runbooks/first-feature-session-log.md` Gap 4

## Design notes

- **Position (before advisor, not before /implement):** AC says "between /plan and /implement"; placement before advisor is a deliberate tightening — advisor was the tool polluted in run #5.
- **Check ordering in implement.md:** Codex SUGGEST to move after step 1 was declined — the check exists to prevent reading a polluted document, so it must fire before deep engagement with plan.md.
- **Exemption rule:** occurrences inside quoted spans or backticks are exempt. Codex flagged underspecification for complex nested-quote scenarios — accepted as known limitation for the current single-entry list. Future multi-term entries should each stay backtick-wrapped in `banned-terms.md` to avoid self-triggering.
- **No plan.md template:** AC #2 offers "comment in plan.md template or dedicated docs/ note." No plan.md template exists in this repo; dedicated doc was the only viable option.

## QA

Carve-out: docs-only diff. No test or docs check required.

## Codex review

Two-voice complete (gpt-5.2). One NIT applied: clarified "inside quoted spans" wording over literal delimiter notation. Two SUGGESTs noted above. One SUGGEST (check ordering) declined with rationale.

## Test plan

- [x] Read-back: lint paragraph at end of step 2 in feature-pipeline.md (before `### 3.`)
- [x] Read-back: `Banned-terms check` block in implement.md Phase 1 (before step 1)
- [x] `docs/runbooks/banned-terms.md` exists with one entry, backtick-wrapped
- [x] Re-install verified: `diff bootstrap/commands/implement.md ~/.claude/commands/implement.md` → IDENTICAL
- [x] /review + @agent-security-reviewer: APPROVE, zero BLOCKs
- [x] /codex-review: no BLOCKs

🤖 Generated with [Claude Code](https://claude.com/claude-code)