### PR TITLE
feat(pipeline): auto-move issues Icebox→In Progress→In Review (#19)

### DIFF
--- a/bootstrap/commands/feature.md
+++ b/bootstrap/commands/feature.md
@@ -1,13 +1,35 @@
 ---
 description: Master orchestrator for feature work. Ведёт по всем стадиям pipeline через TodoWrite.
 argument-hint: <issue-number>
-allowed-tools: Bash(gh issue view:*), Read, TodoWrite
+allowed-tools: Bash(gh issue view:*), Bash(gh project item-list:*), Bash(gh project item-edit:*), Read, TodoWrite
 model: claude-sonnet-4-6
 ---
 
 # /feature
 
 Issue: !`gh issue view $ARGUMENTS --json number,title,body,labels,milestone`
+
+<!-- Project: claude-mini (PVT_kwHOAD4W5M4BVPoL, #5) | Field: Status (PVTSSF_lAHOAD4W5M4BVPoLzhQsxg4) | Options: In Progress=47fc9ee4  In review=b5178a00 -->
+
+**On startup — move issue to In Progress.** Run immediately before creating the checklist. Graceful: warn and continue on any failure.
+
+```bash
+if [ -z "$ARGUMENTS" ]; then
+  echo "⚠ No issue number — skipping status transition"
+else
+  ITEM_ID=$(gh project item-list 5 --owner Lenivvenil --format json \
+    --jq ".items[] | select(.content.number == ($ARGUMENTS | tonumber)) | .id" 2>/dev/null)
+  if [ -n "$ITEM_ID" ]; then
+    gh project item-edit --project-id PVT_kwHOAD4W5M4BVPoL \
+      --id "$ITEM_ID" --field-id PVTSSF_lAHOAD4W5M4BVPoLzhQsxg4 \
+      --single-select-option-id 47fc9ee4 \
+    && echo "✓ Issue #$ARGUMENTS → In Progress" \
+    || echo "⚠ Status transition failed — continuing"
+  else
+    echo "⚠ Issue #$ARGUMENTS not found in claude-mini project — status not updated"
+  fi
+fi
+```
 
 ## Your task
 
@@ -51,6 +73,28 @@ After each stage:
 - **Confirm completion** — ask "Did /plan produce plan.md? Did you call advisor?"
 - **Block bad transitions** — "You're about to /implement but plan.md doesn't exist. Run /plan first."
 - **Recognize ADR branches** — if plan discusses library choice or BC boundary, push hard: "This is ADR territory. Don't skip step 4a."
+
+### Step 2b: Step 11 completion — In Review transition
+
+Immediately after `gh pr create` succeeds (step 11) and before marking step 11 complete, run:
+
+```bash
+if [ -z "$ARGUMENTS" ]; then
+  echo "⚠ No issue number — skipping status transition"
+else
+  ITEM_ID=$(gh project item-list 5 --owner Lenivvenil --format json \
+    --jq ".items[] | select(.content.number == ($ARGUMENTS | tonumber)) | .id" 2>/dev/null)
+  if [ -n "$ITEM_ID" ]; then
+    gh project item-edit --project-id PVT_kwHOAD4W5M4BVPoL \
+      --id "$ITEM_ID" --field-id PVTSSF_lAHOAD4W5M4BVPoLzhQsxg4 \
+      --single-select-option-id b5178a00 \
+    && echo "✓ Issue #$ARGUMENTS → In Review" \
+    || echo "⚠ Status transition failed — continuing"
+  else
+    echo "⚠ Issue #$ARGUMENTS not found in claude-mini project — status not updated"
+  fi
+fi
+```
 
 ### Step 3: Finish
 


### PR DESCRIPTION
Closes #19

## Summary

- Expands `/feature` skill `allowed-tools` with `Bash(gh project item-list:*)` and `Bash(gh project item-edit:*)`
- Adds startup instruction block: on `/feature N` invocation, moves issue #N from Icebox → In Progress in the claude-mini Projects v2 board
- Adds Step 2b instruction: immediately after `gh pr create` at step 11, moves issue #N → In Review
- Hardcoded IDs documented inline via HTML comment per AC #5; graceful degradation on all failure paths

## Implementation notes

- Uses `gh --jq` (no pipe) to avoid `allowed-tools` pattern blocking
- Uses `($ARGUMENTS | tonumber)` in jq filter to validate numeric input and avoid invalid filter syntax on empty `$ARGUMENTS`
- Explicit `[ -z "$ARGUMENTS" ]` guard before each block
- Write-path verified: issue #19 moved to In Progress via actual `gh project item-edit` before merge (exit 0 confirmed)
- **In Review transition is best-effort** — depends on `/feature` skill still being in Claude's context at step 11; context compaction between step 1 and step 11 may skip it. Operator should verify board state after PR creation.

## QA

Carve-out: docs-only diff. No test or docs check required.

## Codex findings addressed

- BLOCK: explicit empty-`$ARGUMENTS` guard added (was previously relying on `$ITEM_ID` empty check)
- BLOCK: `tonumber` in jq filter — validates numeric input, prevents malformed filter on non-integer input
- SUGGEST (multiple matches, portability, stderr masking): noted; not fixed — intentional design per AC #3 and AC #5

## Token scope note

`gh project item-edit` requires the `project` OAuth scope. Verify with `gh auth status`. Graceful degradation swallows failures — check board state manually if transitions silently skip.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>