### PR TITLE
feat(pipeline): sweep per-ticket git worktree isolation (#80)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,16 +9,16 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
         with:
-          scandir: './bootstrap'
+          scandir: '.'
 
   setup-dry-run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install prerequisites
         run: |
           sudo apt-get update
@@ -46,8 +46,8 @@ jobs:
   markdown-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
         with:
           use-quiet-mode: 'yes'
           config-file: '.github/markdown-link-check.json'

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 deploy-to-github.sh
 create-backlog.sh
 *.bak*
+.sweep/

--- a/docs/decisions/0017-sweep-worktree-isolation.md
+++ b/docs/decisions/0017-sweep-worktree-isolation.md
@@ -1,6 +1,6 @@
 # 0017. Sweep per-ticket worktree isolation and abandoned-work contract
 
-* Status: proposed
+* Status: accepted
 * Date: 2026-04-27
 * Deciders: Lenivvenil
 * Tags: pipeline, sweep, git, tooling

--- a/scripts/sweep-worktree.sh
+++ b/scripts/sweep-worktree.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# sweep-worktree.sh — per-ticket git worktree isolation for Autonomous Backlog Sweep
+# ADR-0017: docs/decisions/0017-sweep-worktree-isolation.md
+set -euo pipefail
+IFS=$'\n\t'
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+_sanitize_slug() {
+    local raw="$1"
+    local slug
+    slug=$(printf '%s' "$raw" \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed 's/[^a-z0-9]/-/g; s/-\+/-/g' \
+        | cut -c1-40 \
+        | sed 's/^-*//; s/-*$//')
+    if [[ -z "$slug" ]]; then
+        echo "error: slug is empty after sanitization (input: '$raw')" >&2
+        exit 1
+    fi
+    printf '%s' "$slug"
+}
+
+_validate_ticket_number() {
+    local n="$1"
+    if ! [[ "$n" =~ ^[0-9]+$ ]]; then
+        echo "error: ticket number must be numeric, got: '$n'" >&2
+        exit 1
+    fi
+}
+
+cmd_create() {
+    local n="$1"
+    local raw_slug="$2"
+    _validate_ticket_number "$n"
+    local slug
+    slug=$(_sanitize_slug "$raw_slug")
+    local branch="sweep/${n}-${slug}"
+    local wt_path="${REPO_ROOT}/.sweep/${n}"
+
+    git fetch origin main || {
+        echo "error: git fetch origin main failed — aborting (stale main risks silent corruption)" >&2
+        exit 1
+    }
+
+    git worktree add "${wt_path}" -b "${branch}" origin/main || {
+        echo "error: could not create worktree at '${wt_path}' on branch '${branch}'" >&2
+        echo "hint: if a prior run crashed, clean up with: ./scripts/sweep-worktree.sh cleanup ${n}" >&2
+        exit 1
+    }
+
+    printf '%s\n' "${wt_path}"
+}
+
+cmd_cleanup() {
+    local n="$1"
+    _validate_ticket_number "$n"
+    local wt_path="${REPO_ROOT}/.sweep/${n}"
+    local branch=""
+
+    if [[ -d "${wt_path}" ]]; then
+        branch=$(git -C "${wt_path}" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+
+        # stage untracked files so stash create captures full working state
+        git -C "${wt_path}" add -A 2>/dev/null || true
+        local wip
+        wip=$(git -C "${wt_path}" stash create 2>/dev/null || true)
+        if [[ -n "${wip}" ]]; then
+            git update-ref "refs/sweep-abandoned/${n}" "${wip}"
+            printf 'WIP preserved at refs/sweep-abandoned/%s\nRecover via: git stash apply refs/sweep-abandoned/%s\n' \
+                "${n}" "${n}" >&2
+        fi
+
+        git worktree remove --force "${wt_path}" || true
+    fi
+
+    # branch may exist even if worktree is already gone (partial prior cleanup)
+    if [[ -z "${branch}" ]]; then
+        # prune stale worktree metadata so git branch --list reflects actual state
+        git worktree prune 2>/dev/null || true
+        # strip leading space, *, and + (+ marks worktrees that were prunable)
+        branch=$(git branch --list "sweep/${n}-*" 2>/dev/null | head -1 | tr -d ' *+' || true)
+    fi
+
+    if [[ -n "${branch}" ]]; then
+        git branch -D "${branch}" || true
+    fi
+}
+
+_usage() {
+    printf 'Usage:\n' >&2
+    printf '  %s create <ticket-number> <slug>   create worktree at .sweep/<n>/, branch sweep/<n>-<slug>\n' "$0" >&2
+    printf '  %s cleanup <ticket-number>          remove worktree and branch; preserve WIP to refs/sweep-abandoned/<n>\n' "$0" >&2
+    exit 1
+}
+
+[[ $# -lt 1 ]] && _usage
+
+case "$1" in
+    create)
+        [[ $# -ne 3 ]] && { echo "error: create requires <ticket-number> and <slug>" >&2; _usage; }
+        cmd_create "$2" "$3"
+        ;;
+    cleanup)
+        [[ $# -ne 2 ]] && { echo "error: cleanup requires <ticket-number>" >&2; _usage; }
+        cmd_cleanup "$2"
+        ;;
+    *)
+        echo "error: unknown subcommand '$1'" >&2
+        _usage
+        ;;
+esac


### PR DESCRIPTION
## Summary

- Adds `scripts/sweep-worktree.sh` — `create`/`cleanup` subcommands for per-ticket `git worktree` isolation (ADR-0017)
- WIP preserved to `refs/sweep-abandoned/<n>` on cleanup via `git stash create` (captures untracked files)
- Ticket number validated as numeric before use in git refs/paths (security: prevents path traversal)
- `.sweep/` added to `.gitignore`
- CI: ShellCheck `scandir` corrected to `'.'` (covers both `bootstrap/` and `scripts/`); all GitHub Actions pinned to commit SHAs

Closes #80
Implements docs/decisions/0017-sweep-worktree-isolation.md

## QA

**Tests:** No test harness for shell scripts. Escape hatch applied. Add ## QA section to PR body noting this before merge.

New shell script `scripts/sweep-worktree.sh` with no automated harness. Manual protocol executed during `/implement` — all 7 cases passed:

1. `create 101 foo-feature` — clean worktree, correct branch `sweep/101-foo-feature` ✓
2. `create 102 bar-fix` — concurrent, clean, `sweep/102-bar-fix` ✓
3. `git worktree list` — two entries on separate branches ✓
4. `cleanup 101` with untracked WIP — `refs/sweep-abandoned/101` created, file captured in stash commit ✓
5. `cleanup 999` (non-existent) — exits 0 (idempotent) ✓
6. `cleanup 102` (clean worktree) — branch deleted, no ref created ✓
7. `cleanup 104` after `rm -rf .sweep/104` (stale-metadata) — `git worktree prune` runs, branch deleted ✓

ShellCheck: clean. Consider introducing bats: `brew install bats-core`.

**Docs:** All contracts current. ADR-0017 is the public contract. Operator UX surface deferred to Epic #44 Phase-1 per ADR Out-of-Scope clause.

## Review findings resolved

| Finding | Source | Action |
|---|---|---|
| `n` not validated — ref/path traversal | security-reviewer BLOCK | Fixed: `_validate_ticket_number` rejects non-numeric |
| `scandir: './bootstrap ./scripts'` broken | Codex caught | Fixed: `scandir: '.'` |
| Floating action refs | security-reviewer + Codex | Fixed: all pinned to commit SHAs |
| ADR-0017 status `proposed` after merge | /review NIT | Fixed: `accepted` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)