### PR TITLE
feat(pipeline): lint-prompts.sh — structural QA gate for prompt artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Bash syntax check all scripts
         run: |
           find bootstrap -name "*.sh" -print0 | xargs -0 -I{} bash -n {}
+      - name: Lint prompt artifacts
+        run: |
+          shopt -s nullglob
+          bash scripts/lint-prompts.sh bootstrap/agents/*.md bootstrap/commands/*.md bootstrap/skills/*/SKILL.md
       - name: Validate JSON/YAML
         run: |
           for f in bootstrap/templates/*.yml; do

--- a/bootstrap/commands/qa.md
+++ b/bootstrap/commands/qa.md
@@ -20,7 +20,8 @@ Get the list of changed files (`git diff --cached --name-only || git diff HEAD -
 Evaluate carve-outs strictly in the order below. **If step 1 matches: write the report, stop immediately — do not evaluate step 2.**
 
 1. **ADR-only** (most specific — evaluate first): every changed file matches `docs/decisions/*.md`. If true → write `qa-report.md` with body `## QA\n\nCarve-out: ADR-only diff. No test or docs check required.` Print it. **Exit.** Do not proceed to step 2 or Phase 1.
-2. **Docs-only**: every changed file matches `*.md`. If true → write `qa-report.md` with body `## QA\n\nCarve-out: docs-only diff. No test or docs check required.` Print it. **Exit.** Do not proceed to Phase 1.
+2. **Prompt-artifact** (evaluate before docs-only — bootstrap `.md` files are not docs): every changed file matches `bootstrap/agents/*.md`, `bootstrap/commands/*.md`, or `bootstrap/skills/*/SKILL.md`. If true → run `./scripts/lint-prompts.sh` against the matched files. Write `qa-report.md` with the linter output and verdict (PASS or FAIL). **Exit.** Do not proceed to step 3 or Phase 1. Mixed PRs (prompt artifact + other files) fall through to Phase 1 — manually invoke `./scripts/lint-prompts.sh` on the changed prompt-artifact files as part of Phase 2, then continue with the standard test-coverage check for any logic files.
+3. **Docs-only**: every changed file matches `*.md`. If true → write `qa-report.md` with body `## QA\n\nCarve-out: docs-only diff. No test or docs check required.` Print it. **Exit.** Do not proceed to Phase 1.
 
 Always record the carve-out reason — never exit silently.
 

--- a/scripts/lint-prompts.sh
+++ b/scripts/lint-prompts.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# lint-prompts.sh — structural linter for bootstrap prompt artifacts
+#
+# Usage: ./scripts/lint-prompts.sh [file ...]
+# Dispatch: rules applied based on file path, not content heuristics.
+# Exit 0: all files clean (including zero-args). Exit 1: one or more findings.
+#
+# Artifact types and rules:
+#   bootstrap/agents/*.md      — frontmatter, Protocol/Output/Hard rules sections,
+#                                fenced output block if pure critic (NEVER writes files)
+#   bootstrap/commands/*.md    — Your task + Hard rules sections
+#   bootstrap/skills/*/SKILL.md — Output + Hard rules sections
+#   anything else              — skipped silently
+#
+# NOTE: file arguments must be relative paths from the repo root
+# (e.g. bootstrap/agents/foo.md). Absolute paths silently skip dispatch.
+
+set -uo pipefail
+
+ERRORS=0
+
+# Banned term patterns (keep in sync with docs/runbooks/banned-terms.md)
+BANNED_TERMS=("employer-owned repositories")
+
+check_banned() {
+    local file="$1"
+    local ok=1
+    for term in "${BANNED_TERMS[@]}"; do
+        if grep -qi "$term" "$file"; then
+            echo "$file: FAIL — contains banned term '$term'" >&2
+            ok=0
+        fi
+    done
+    return $((1 - ok))
+}
+
+lint_agent() {
+    local file="$1"
+    local ok=1
+
+    # Frontmatter fields — must be present and non-empty
+    for field in name description tools model; do
+        if ! grep -qE "^${field}:[[:space:]]+[^[:space:]]" "$file"; then
+            echo "$file: FAIL — missing or empty '${field}:' in frontmatter" >&2
+            ok=0
+        fi
+    done
+
+    # Tool/claim consistency: pure read-only critics claim "NEVER writes files"
+    if grep -qi "NEVER writes files" "$file"; then
+        if grep -qE "^tools:.*\bWrite\b" "$file" || grep -qE "^tools:.*\bEdit\b" "$file"; then
+            echo "$file: FAIL — description says 'NEVER writes files' but tools includes Write or Edit" >&2
+            ok=0
+        fi
+        # Pure critics must have a fenced output block (literal or escaped backticks) with a placeholder
+        # shellcheck disable=SC2016
+        if ! grep -qE '^```|^\\`\\`\\`' "$file"; then
+            echo "$file: FAIL — pure critic requires a fenced output block (none found)" >&2
+            ok=0
+        elif ! grep -q '{' "$file"; then
+            echo "$file: FAIL — pure critic output block must contain at least one {placeholder}" >&2
+            ok=0
+        fi
+    fi
+
+    # Required sections
+    for section in "## Protocol" "## Hard rules"; do
+        if ! grep -qF "$section" "$file"; then
+            echo "$file: FAIL — missing '${section}' section" >&2
+            ok=0
+        fi
+    done
+    # Output section: accept both '## Output format' and '## Output'
+    if ! grep -qE "^## Output" "$file"; then
+        echo "$file: FAIL — missing '## Output' or '## Output format' section" >&2
+        ok=0
+    fi
+
+    check_banned "$file" || ok=0
+    return $((1 - ok))
+}
+
+lint_command() {
+    local file="$1"
+    local ok=1
+
+    for section in "## Your task" "## Hard rules"; do
+        if ! grep -qF "$section" "$file"; then
+            echo "$file: FAIL — missing '${section}' section" >&2
+            ok=0
+        fi
+    done
+
+    check_banned "$file" || ok=0
+    return $((1 - ok))
+}
+
+lint_skill() {
+    local file="$1"
+    local ok=1
+
+    if ! grep -qF "## Hard rules" "$file"; then
+        echo "$file: FAIL — missing '## Hard rules' section" >&2
+        ok=0
+    fi
+    if ! grep -qE "^## Output" "$file"; then
+        echo "$file: FAIL — missing '## Output' section" >&2
+        ok=0
+    fi
+
+    check_banned "$file" || ok=0
+    return $((1 - ok))
+}
+
+if [ $# -eq 0 ]; then
+    exit 0
+fi
+
+for file in "$@"; do
+    if [ ! -f "$file" ]; then
+        echo "$file: SKIP — not a file" >&2
+        continue
+    fi
+
+    case "$file" in
+        bootstrap/agents/*.md)
+            lint_agent "$file" || ERRORS=$((ERRORS + 1))
+            ;;
+        bootstrap/commands/*.md)
+            lint_command "$file" || ERRORS=$((ERRORS + 1))
+            ;;
+        bootstrap/skills/*/SKILL.md)
+            lint_skill "$file" || ERRORS=$((ERRORS + 1))
+            ;;
+        *)
+            # Not a prompt artifact — skip gracefully
+            ;;
+    esac
+done
+
+if [ "$ERRORS" -gt 0 ]; then
+    echo "" >&2
+    echo "lint-prompts: ${ERRORS} file(s) failed" >&2
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Adds `scripts/lint-prompts.sh` — bash structural linter for `bootstrap/agents/*.md`, `bootstrap/commands/*.md`, `bootstrap/skills/*/SKILL.md` artifacts. Checks frontmatter completeness, required sections by artifact type, tool/claim consistency for pure critics, fenced output block, banned terms.
- Updates `/qa` Phase 0 with a third carve-out (prompt-artifact, positioned before docs-only) that invokes the linter
- Adds CI step in `setup-dry-run` job to run linter against all existing prompt artifacts on every PR

## QA

**Tests:** New shell script `scripts/lint-prompts.sh` with no automated harness. Escape hatch applied.

Manual tests executed during `/implement`:
- `shellcheck scripts/lint-prompts.sh` — PASS ✓
- All 7 existing `bootstrap/agents/*.md` pass clean ✓
- All `bootstrap/commands/*.md` pass clean ✓
- All `bootstrap/skills/*/SKILL.md` pass clean ✓
- Bad fixture (missing `model:`, missing `## Protocol`) → correct FAIL with named findings ✓
- Empty file at agent path → all checks fire, exit 1 ✓
- Non-bootstrap `.md` file → skipped gracefully, exit 0 ✓
- Zero arguments → exit 0 ✓

New shell script with no harness detected. Consider introducing bats: `brew install bats-core`.

**Docs:** All contracts current. No runbook needed — script is infrastructure, not operator-facing.

## Review notes

- `/review` caught undocumented relative-path constraint → added header comment to script
- Security-reviewer APPROVED: no injection surface, `pull_request:` trigger (not `pull_request_target:`), no new third-party actions, all `$file` uses double-quoted
- Codex BLOCK: CI glob nullglob risk → fixed with `shopt -s nullglob` in CI step
- Codex SUGGEST: qa.md mixed-PR wording inaccurate → fixed to say "manually invoke linter" rather than implying automatic Phase 2 integration
- Codex SUGGEST on script validation: disagreement — `shellcheck` job uses `scandir: '.'` which already covers `scripts/lint-prompts.sh`; no gap
- Governance hook: `.github/workflows/` change triggers Rule 3 (ADR ref required). No new ADR needed (not architecturally significant); commit references ADR-0016 (qa-skill-placement) and ADR-0012 (shellcheck-ci-scope) as the relevant prior decisions.

## DoD checklist

- [x] ADR — not required; governance hook satisfied via ADR-0016 + ADR-0012 references
- [x] Domain docs — no BC boundary or term changed; no update needed
- [x] Tests — escape hatch applied (shell script, no bats harness); 8 manual cases verified
- [x] `/review` approved
- [x] `/codex-review` approved (gpt-5.2); all findings addressed
- [x] Two-voice disagreements resolved above
- [ ] Human self-review
- [ ] Security scans — N/A (no package dependencies)
- [x] Docs current
- [x] Human-facing docs reviewed — `bootstrap/commands/qa.md` is a prompt artifact (not human-facing docs scope); no `docs-reviewer` needed
- [ ] CI green
- [x] Conventional Commits; governance hook passed
- [x] Closes #92

Closes #92