### PR TITLE
fix(governance): fail-closed on missing jq and malformed stdin

### DIFF
--- a/bootstrap/hooks/pre-commit-governance.sh
+++ b/bootstrap/hooks/pre-commit-governance.sh
@@ -35,11 +35,24 @@ log() {
     echo "[pre-commit-governance] $*" >&2
 }
 
+# --- jq prerequisite check (fail-closed, not fail-open) ---
+
+if ! command -v jq >/dev/null 2>&1; then
+    # Use printf (bash builtin) — cat is not available without jq in minimal PATH
+    printf '{"hookSpecificOutput":{"permissionDecision":"deny","permissionDecisionReason":"pre-commit-governance: jq not found. Install jq to enable commit governance (brew install jq)."}}\n'
+    exit 2
+fi
+
 # --- Read input ---
 
 input=$(cat)
-command=$(echo "$input" | jq -r '.tool_input.command // empty')
-cwd=$(echo "$input" | jq -r '.cwd // empty')
+command=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+cwd=$(echo "$input" | jq -r '.cwd // empty' 2>/dev/null || true)
+
+# Fail-closed on unparseable stdin — empty command on non-empty input means malformed JSON
+if [ -n "$input" ] && [ -z "$command" ] && [ -z "$cwd" ]; then
+    json_deny "pre-commit-governance: could not parse stdin as JSON (input non-empty but both fields empty). Check hook invocation."
+fi
 
 # --- Early exit: not a git commit ---
 

--- a/bootstrap/scripts/test-governance-hook.sh
+++ b/bootstrap/scripts/test-governance-hook.sh
@@ -112,6 +112,30 @@ assert_allowed() {
     pass "$label"
 }
 
+# --- Fail-closed cases (must be blocked, not fail-open) ---
+
+echo "Fail-closed cases (must be blocked with exit 2, not silently allowed):"
+
+# Malformed stdin — hook must deny, not fail-open
+malformed_result=$(echo "not-valid-json" | bash "$HOOK" 2>/dev/null; echo "exit=$?")
+malformed_exit=$(echo "$malformed_result" | grep -oE 'exit=[0-9]+' | tail -1 | cut -d= -f2)
+if [ "$malformed_exit" = "2" ]; then
+    pass "malformed stdin — exit 2 (fail-closed)"
+else
+    fail "malformed stdin — expected exit 2, got exit $malformed_exit (fail-open!)"
+fi
+
+# jq-absent: structural check — hook must contain a fail-closed guard
+# (Runtime simulation with restricted PATH is unreliable across environments)
+if grep -q 'command -v jq' "$HOOK" && grep -q "exit 2" "$HOOK" && \
+   grep -A3 'command -v jq' "$HOOK" | grep -q 'printf\|json_deny'; then
+    pass "jq absent guard — structural check present (fail-closed on missing jq)"
+else
+    fail "jq absent guard — not found in hook source (hook may fail-open when jq missing)"
+fi
+
+echo ""
+
 # --- Bad commit cases (must be blocked) ---
 
 echo "Bad commits (must be blocked with exit 2):"


### PR DESCRIPTION
Closes #109

## Problem

`pre-commit-governance.sh` failed open in two cases:
1. **jq absent** — `command=$(echo "$input" | jq ...)` silently returns empty string; `grep` for `git commit` fails; hook exits 0, allowing all commits
2. **Malformed stdin** — same empty-string outcome; same silent bypass

Both were documented in Red Hotspot #8 / `incident-recovery.md` but not mitigated in the hook itself.

## Fix

- **jq check** at top of hook using `printf` (bash builtin — works even with restricted PATH); exits 2 with `permissionDecision: deny` and install hint
- **Malformed stdin check** after jq parse: if `$input` non-empty but both `$command` and `$cwd` are empty, deny

## Tests

`test-governance-hook.sh` extended:
- `malformed stdin → exit 2` — runtime test (passes)
- `jq absent guard` — structural grep (runtime PATH mock unreliable cross-env)

All 9 assertions green; existing governance tests unchanged.

## QA

`lint-prompts.sh` N/A (shell script). `test-governance-hook.sh` — 9/9 pass. `test-install-verification.sh` regression: governance hook smoke test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)