### PR TITLE
chore(backlog): preserve weekly grooming reports (Refs #142)

### DIFF
--- a/docs/backlog/grooming-2026-04-24.md
+++ b/docs/backlog/grooming-2026-04-24.md
@@ -1,0 +1,220 @@
+# Backlog grooming report — 2026-04-24
+
+**Stats:** 28 open issues. Median age 3 days, P90 age 3 days. Distribution: 13 issues from 2026-04-21 (initial seed batch), 15 issues from 2026-04-23/24 (active week). Zero issues older than 60 days — repo is too young for stale candidates by date alone, but several issues are blocked by other open issues with no ETA which is the practical equivalent.
+
+Label scheme observed (mixed — see Check 4):
+- Old scheme (issues #4-12): `type:*`, `P*-*`, `estimate/*`, `area:*`, `adr-needed`
+- New scheme (issues #18-41): `enhancement`, `bug`, `pipeline`, `documentation`, `needs-triage`
+- Deferred-review subset (#29, #33, #35, #37): `type:deferred-review` only
+
+---
+
+## 1. Suspected duplicates
+
+| Pair | Evidence | Proposed action |
+|---|---|---|
+| #29, #33, #35, #37 | All four are auto-generated "Deferred codex review" issues from `review-codex.sh` skip path. Same template, same workflow, four separate commits in 24h. Pattern indicates a systemic Codex/Plus quota problem, not four independent issues. | Roll up into a single tracking issue "Codex Plus quota exhausted — backlog of deferred reviews" and link the four commit hashes; close the four after consolidating. |
+| #31 + #32 | Both are bootstrap installer architecture spikes that explicitly cross-reference each other. #32 declares "Depends on" #31 ("decide manifest question first; orphan policy follows from that choice"). Not duplicates but tightly coupled — should be sequenced via parent epic or sub-issue link. | Make #32 a sub-issue of #31 (or add explicit `blocked-by` label) so the dependency is queryable. |
+| #40 + #41 | #40 = "fix 14 pre-existing shellcheck findings". #41 = "scope shellcheck CI to changed files only". Same root cause (PR #39 CI failure on pre-existing debt). Not duplicates — they are the two competing solutions. Resolution of #41 (option a/b/c) likely makes #40 partial or moot. | Add `blocked-by #41` to #40; #41 is the decision, #40 is the fix path under option (c). |
+
+```bash
+# Deferred-review consolidation
+gh issue create --title "Codex Plus quota exhausted: backlog of 4 deferred reviews" \
+  --body "Tracks systemic skip pattern. Children: #29, #33, #35, #37. Decide whether to (a) wait for quota reset and bulk re-run, (b) switch to API key for Codex, (c) accept deferred-review as steady state and drop ADR 0005 single-voice fallback." \
+  --label "type:spike,area:governance"
+gh issue comment 29 --body "Rolled up into parent tracking issue (above)."
+gh issue comment 33 --body "Rolled up into parent tracking issue (above)."
+gh issue comment 35 --body "Rolled up into parent tracking issue (above)."
+gh issue comment 37 --body "Rolled up into parent tracking issue (above)."
+
+# Sequencing
+gh issue edit 32 --add-label "blocked-by:31"
+gh issue edit 40 --add-label "blocked-by:41"
+```
+
+---
+
+## 2. Missing acceptance criteria
+
+Issues typed `Feature`/`Bug`/`enhancement` whose body has neither `## Acceptance criteria` nor `## Definition of Done`:
+
+- [ ] **#18** "/feature pipeline: auto-invoke adr-reviewer after solutions-architect" — `enhancement,pipeline` — has a one-line "Acceptance:" inline, but no checklist; reviewable but not measurable.
+- [ ] **#19** "/feature pipeline: move issue Icebox → In Progress in Projects v2" — same shape as #18.
+- [ ] **#20** "hook: sanitize reason before JSON heredoc" — no AC, no DoD; bug repro implicit only.
+- [ ] **#21** "hook: tighten issue-ref regex in Rule 2" — no AC.
+- [ ] **#22** "runbook: replace line-number references with anchors" — no AC.
+- [ ] **#23** "hook: consolidate duplicated -m message extraction" — no AC.
+- [ ] **#25** "installer: --force should be default OR diff-and-warn" — has trailing "Acceptance:" sentence but no checkable criteria; also presents three unresolved options (A/B/C) without a decision path → ADR territory.
+- [ ] **#27** "installer: universal-setup.sh fails in subshells" — body empty; only title.
+- [ ] **#40** "shellcheck debt: fix 14 pre-existing findings" — no AC, no DoD; scope listed but no exit criterion (count == 0? per-file?).
+- [ ] **#41** "CI design: scope shellcheck to changed files" — no AC; presents options (a/b/c) without decision path → ADR territory like #25.
+
+Issues #4, #5, #6, #7, #8, #9, #10, #11, #12, #16, #17, #31, #32, #38 — **have** AC sections (passing).
+
+```bash
+# Bulk-flag issues missing AC
+for n in 18 19 20 21 22 23 25 27 40 41; do
+  gh issue edit "$n" --add-label "needs-ac"
+done
+
+# Extra: #27 has empty body — needs reproduction steps before AC is even possible
+gh issue edit 27 --add-label "needs-repro"
+
+# Extra: #25 and #41 propose options without decision — should escalate to ADR
+gh issue edit 25 --add-label "adr-needed"
+gh issue edit 41 --add-label "adr-needed"
+```
+
+---
+
+## 3. Stale candidates
+
+Strict 60-day rule: no issue qualifies (oldest open is 3 days). Adapted criterion: **issues with no clear owner, no scheduled milestone, and either (a) hard dependency on another open issue or (b) observational/long-window AC that needs operator-side discipline that hasn't started.**
+
+- [ ] **#4** "Empirically confirm advisor Opus billing" (P1, 3d old) — observational spike requires deliberate `/usage` snapshots. No assignee; no evidence the baseline was taken on 21 Apr. Risk: window slides indefinitely. **Action:** assign owner or downgrade to P2 until owner exists.
+- [ ] **#7** "Establish weekly /project-health rhythm" (P2, 3d old) — needs first Friday run; today (2026-04-24) **is Friday** — natural trigger point. Otherwise becomes stale by definition.
+- [ ] **#8** "Verify two-voice review catches real miss (30-day window)" — has 1 datapoint comment from 21 Apr (#1 PR, 2 codex catches). Window started; on track. **No action.**
+- [ ] **#6** "Enrich onboarding-repo runbook from first real practice" — explicitly blocked by #5 ("First real feature through full pipeline"). Status of #5 is unclear — no assignee, no progress comments. **Action:** add `blocked-by:5`; revisit after #5 closes.
+- [ ] **#12** "Test incident-recovery runbook" (P3, 3d old) — drill-style; will silently rot until forced. Acceptable for P3 but tag `chore:scheduled` so it surfaces in next groom.
+
+```bash
+# Owner / priority hygiene
+gh issue edit 4 --add-assignee Lenivvenil   # or downgrade if no owner
+gh issue comment 7 --body "Today is Friday 2026-04-24 — natural trigger for first /project-health run."
+gh issue edit 6 --add-label "blocked-by:5"
+gh issue edit 12 --add-label "chore:scheduled"
+```
+
+No issue qualifies for **close-as-stale**.
+
+---
+
+## 4. Inconsistent labels
+
+The repo is mid-migration between two label schemes. This is the highest-impact finding.
+
+| Issue | Old-scheme labels | New-scheme labels | Conflict |
+|---|---|---|---|
+| #18 | — | `enhancement`, `pipeline` | Missing `type:feature` (new repo convention?), missing priority, missing estimate, missing area |
+| #19 | — | `enhancement`, `pipeline` | same |
+| #20 | — | `bug`, `pipeline` | Missing `type:bug`, priority, estimate, area |
+| #21 | — | `enhancement`, `pipeline` | same as #18 |
+| #22 | — | `documentation` | Missing type, priority, estimate, area |
+| #23 | — | `enhancement`, `pipeline` | same |
+| #25 | — | `bug`, `pipeline` | same as #20 |
+| #27 | — | `bug`, `pipeline` | same |
+| #29, #33, #35, #37 | — | `type:deferred-review` only | No priority, no area, no estimate |
+| #31, #32 | `needs-triage`, `type:spike`, `area:bootstrap`, `adr-needed` | — | `needs-triage` co-existing with full classification suggests triage is incomplete; should be removed once triaged |
+| #38 | `P3-low`, `type:chore` | — | Missing `area:` (touches `bootstrap/`, `docs/`, `CLAUDE.md`) |
+| #40 | — | (no labels) | Completely unlabeled |
+| #41 | — | (no labels) | Completely unlabeled, also `adr-needed` candidate |
+
+Worse: GitHub's repo-level labels include both `bug` and `type:bug`, both `enhancement` and `type:feature` — two parallel schemes. Either consolidate or write a label-policy ADR.
+
+```bash
+# 1. Triage clean-up — #31 and #32 are fully classified; drop needs-triage
+gh issue edit 31 --remove-label "needs-triage"
+gh issue edit 32 --remove-label "needs-triage"
+
+# 2. Backfill priorities on the 2026-04-23/24 batch (sample defaults; operator must adjust)
+gh issue edit 18 --add-label "P2-medium,type:feature,area:pipeline,estimate/2"
+gh issue edit 19 --add-label "P2-medium,type:feature,area:pipeline,estimate/2"
+gh issue edit 20 --add-label "P2-medium,type:bug,area:hooks,estimate/1"
+gh issue edit 21 --add-label "P3-low,type:bug,area:hooks,estimate/1"
+gh issue edit 22 --add-label "P3-low,type:chore,area:docs,estimate/1"
+gh issue edit 23 --add-label "P3-low,type:chore,area:hooks,estimate/2"
+gh issue edit 25 --add-label "P1-high,type:bug,area:bootstrap,estimate/3"
+gh issue edit 27 --add-label "P2-medium,type:bug,area:bootstrap,estimate/2"
+gh issue edit 38 --add-label "area:docs,area:bootstrap"
+gh issue edit 40 --add-label "P3-low,type:chore,area:bootstrap,estimate/3"
+gh issue edit 41 --add-label "P2-medium,type:spike,area:ci,adr-needed,estimate/2"
+
+# 3. Deferred-review batch — assign priority + area
+for n in 29 33 35 37; do
+  gh issue edit "$n" --add-label "P3-low,area:governance"
+done
+
+# 4. Open an ADR to canonicalise the label scheme (recommended)
+# (operator action; use /adr command)
+```
+
+---
+
+## 5. Orphan sub-issues
+
+GitHub MCP returned no formal parent/child sub-issue links for any of the 28 open issues. Body-level dependency mentions:
+
+- **#6** body says "Зависит от" #5 — informal, not a graph edge.
+- **#32** body says "Depends on" #31 — informal.
+- Implicit chain: #31 (manifest decision) → #32 (orphan removal) → installer rework that #25/#27 also touch. None linked formally.
+- **#5** epic ("First real feature through full pipeline") implicitly parents #6, and arguably #11.
+
+No orphans where parent is closed and child remains open.
+
+```bash
+# Convert informal dependencies into queryable sub-issue links
+# (operator must resolve issue-node IDs first)
+gh api graphql -f query='{ repository(owner:"Lenivvenil",name:"claude-mini"){ issue(number:5){ id } } }'
+# Then: gh api graphql -f query='mutation { addSubIssue(input:{issueId:"<id-of-5>", subIssueId:"<id-of-6>"}) { issue { number } } }'
+gh api graphql -f query='mutation { addSubIssue(input:{issueId:"<id-of-31>", subIssueId:"<id-of-32>"}) { issue { number } } }'
+```
+
+---
+
+## 6. Missing ADR links
+
+- **#9** "Phase 2 governance: add git-level commit-msg hook" — has `adr-needed`. Plans "ADR 0009". No ADR file linked yet. **No action other than verify ADR is opened before implementation.**
+- **#31** "Bootstrap completeness: implicit tree vs explicit manifest" — `adr-needed`. References ADR 0008 and ADR 0010. **No action.**
+- **#32** "Installer does not remove orphans" — `adr-needed`. References ADR 0010. **No action.**
+- **#25** "installer: --force should be default OR diff-and-warn" — presents three options; should be `adr-needed` (added under Check 2 above).
+- **#41** "CI design: scope shellcheck to changed files only" — should be `adr-needed` (added under Check 2 above).
+- **#8** "Verify two-voice review catches real miss" — outcome may close/supersede ADR 0005. Worth tagging `adr-followup`.
+
+```bash
+gh issue edit 8 --add-label "adr-followup"
+```
+
+---
+
+## Summary table
+
+| # | Title | Age | Priority | AC? | Labels OK? | Blocked by | Action |
+|---|---|---|---|---|---|---|---|
+| 4 | Confirm advisor Opus billing | 3d | P1 | yes | yes | — | assign owner |
+| 5 | First real feature E2E | 3d | P1 (epic) | yes | yes | — | start; parent of #6, #11 |
+| 6 | Enrich onboarding runbook | 3d | P2 | yes | yes | #5 | add blocked-by |
+| 7 | Weekly /project-health rhythm | 3d | P2 | yes | yes | — | trigger today (Fri) |
+| 8 | Two-voice 30-day window | 3d | P2 | yes | yes | — | tag adr-followup; ongoing |
+| 9 | Git-level commit-msg hook | 3d | P1 | yes | yes | — | needs ADR 0009 first |
+| 10 | CI templates E2E validate | 3d | P2 | yes | yes | — | — |
+| 11 | Populate docs/domain/ | 3d | P3 | yes | yes | — | — |
+| 12 | Test incident-recovery runbook | 3d | P3 | yes | yes | — | tag chore:scheduled |
+| 16 | macOS bash 3.2 incompat | 3d | P2 | inline | yes | — | — |
+| 17 | Ghostty terminfo | 3d | P3 | inline | yes | — | — |
+| 18 | adr-reviewer auto-invoke | 1d | unset | no | no | — | label, AC |
+| 19 | Projects v2 status auto-move | 1d | unset | no | no | — | label, AC |
+| 20 | Hook JSON heredoc sanitize | 1d | unset | no | no | — | label, AC |
+| 21 | Hook issue-ref regex | 1d | unset | no | no | — | label, AC |
+| 22 | Runbook anchors not line refs | 1d | unset | no | no | — | label, AC |
+| 23 | Hook -m extraction refactor | 1d | unset | no | no | — | label, AC |
+| 25 | Installer --force default | 1d | unset | no | no | — | label, AC, adr-needed |
+| 27 | Installer subshell failure | 1d | unset | no | no | — | label, AC, repro body |
+| 29 | Deferred codex review b68f3b6 | 1d | unset | n/a | partial | — | roll up |
+| 31 | Bootstrap manifest spike | 1d | unset | yes | partial | — | drop needs-triage |
+| 32 | Orphan removal spike | 1d | unset | yes | partial | #31 | drop needs-triage; link |
+| 33 | Deferred codex review 758839e | 1d | unset | n/a | partial | — | roll up |
+| 35 | Deferred codex review cc08e7c | 0d | unset | n/a | partial | — | roll up |
+| 37 | Deferred codex review fbd2f91 | 0d | unset | n/a | partial | — | roll up |
+| 38 | Language policy EN-only | 0d | P3 | yes | partial | — | add area:* |
+| 40 | shellcheck debt 14 findings | 0d | unset | no | no | #41 | label, AC, blocked-by |
+| 41 | CI scope shellcheck to changed | 0d | unset | no | no | — | label, AC, adr-needed |
+
+---
+
+## Top recommendations (operator priority order)
+
+1. **Resolve label-scheme split.** Two parallel schemes (`bug`+`type:bug`, `enhancement`+`type:feature`) will keep producing inconsistency on every new issue. Either rename or pick one and write an ADR. Affects 11 of 28 open issues.
+2. **Roll up the four deferred-codex-review issues** into one tracking issue. Otherwise each future skip will create another standalone issue and the "30-day window" of #8 becomes hard to evaluate.
+3. **Trigger #7 today** — today is Friday 2026-04-24, the natural inception point for the weekly rhythm.
+4. **Sequence #31 → #32 → installer rework** explicitly via sub-issue links so #25 (which assumes installer behaviour) doesn't get implemented before the manifest decision.
+5. **Backfill AC + labels** on the 10 issues called out in Check 2 / Check 4 before any of them enter `/feature`.

--- a/docs/backlog/grooming-2026-04-26.md
+++ b/docs/backlog/grooming-2026-04-26.md
@@ -1,0 +1,208 @@
+# Backlog grooming report — 2026-04-26
+
+**Stats:** 16 open issues, median age 3 days, P90 age 5 days. No issues exceed the 60-day stale threshold (oldest is 5 days). Repo is young; emphasis falls on duplicates, structural consistency, and unblock-edges over decay.
+
+## Inventory
+
+| # | Title | Labels | Age (d) | Notes |
+|---|---|---|---|---|
+| 49 | runbook: document --hook-this-repo step in onboarding-repo.md | type:runbook, P3-low, area:docs, area:bootstrap | 2 | Has AC + DoD |
+| 48 | pipeline: re-validate plan.md against ADR after ADR merges | P3-low, type:chore, area:pipeline | 2 | Has AC + DoD |
+| 44 | Epic: Autonomous Backlog Sweep — blocked by pipeline stabilization | blocked, epic | 2 | Blocker list references closed #41 |
+| 38 | Language policy: EN-only for project artifacts | P3-low, area:docs, area:bootstrap, type:chore | 2 | Has AC |
+| 32 | Installer does not remove orphans | blocked, type:spike, area:bootstrap, adr-needed | 3 | Depends on #31 |
+| 31 | Bootstrap completeness: implicit tree vs explicit manifest | type:spike, area:bootstrap, adr-needed | 3 | Has AC |
+| 23 | hook: consolidate duplicated -m message extraction | enhancement, P3-low, estimate/2, area:hooks, pipeline, type:chore, needs-ac | 3 | needs-ac label |
+| 22 | runbook: replace line-number references with anchors | documentation, P3-low, estimate/1, area:docs, type:chore, needs-ac | 3 | needs-ac label |
+| 21 | hook: tighten issue-ref regex in Rule 2 | enhancement, type:bug, P3-low, estimate/1, area:hooks, pipeline, needs-ac | 3 | Conflicting `enhancement` + `type:bug`; needs-ac |
+| 19 | /feature pipeline: move issue Icebox → In Progress | enhancement, type:feature, P2-medium, estimate/2, pipeline, needs-ac, area:pipeline | 3 | Conflicting `enhancement` + `type:feature`; AC inline but no header |
+| 17 | Ghostty xterm-ghostty terminfo missing on mini | type:bug, P3-low, estimate/1, area:bootstrap | 5 | AC inline (no header) |
+| 16 | macOS default bash 3.2 incompatible with bootstrap scripts | type:bug, P2-medium, estimate/3, area:bootstrap | 5 | AC inline (no header) |
+| 12 | Test incident-recovery runbook on real incident or planned drill | type:runbook, P3-low, estimate/5, area:docs, chore:scheduled | 5 | Has AC + DoD |
+| 10 | End-to-end validate CI workflow templates on real project | type:feature, P2-medium, estimate/5, area:ci, area:bootstrap | 5 | Has AC + DoD |
+| 7  | Establish weekly /project-health rhythm | type:feature, P2-medium, estimate/2, area:docs | 5 | Has AC + DoD |
+| 6  | Enrich onboarding-repo runbook from first real practice | blocked, type:runbook, P2-medium, estimate/3, area:docs | 5 | Blocker (#5) is now CLOSED — should be unblocked |
+
+---
+
+## 1. Suspected duplicates
+
+| Pair | Evidence | Proposed action |
+|---|---|---|
+| #21 + #23 | Both target `pre-commit-governance.sh`, both flagged in same /review during #14, both `area:hooks` + `pipeline` + `P3-low` + `needs-ac`. Distinct concerns (regex tightening vs. -m extraction refactor) but tightly coupled — same file, same review pass, same priority. | Not a true content duplicate, but candidates for **bundling** into a single "hook hardening" story to amortise the review cycle. Add cross-reference, do not merge. |
+| #31 + #32 | Both spikes, both `adr-needed`, both `area:bootstrap`, both reference issue #3 history, both authored within seconds of each other. #32 explicitly states "Depends on #31" (Option C couples them). | Keep both; ensure #32 declares hard-block on #31. Cross-link is already in #32 prose but no `blocked` relationship is enforced via labels alone. |
+
+```bash
+# #21 + #23 — cross-link only, no merge
+gh issue comment 21 --body "Related: #23 (sibling hook-hardening item from same /review during #14). Consider bundling into one PR."
+gh issue comment 23 --body "Related: #21 (sibling hook-hardening item from same /review during #14). Consider bundling into one PR."
+```
+
+```bash
+# #31 + #32 — make the dependency machine-readable
+gh issue edit 32 --add-label blocked
+gh issue comment 32 --body "Hard-blocked by #31: orphan-removal policy (Option C) couples to manifest decision. Will revive after #31 ADR merges."
+```
+
+No true content duplicates were found.
+
+---
+
+## 2. Missing acceptance criteria
+
+Issues typed `Feature` or `Bug` without an explicit `## Acceptance criteria` or `## Definition of done` heading. Note: #21, #19, #17, #16 do contain AC-like text inline but lack the structured heading required by the convention.
+
+- [ ] **#16** "macOS default bash 3.2 incompatible" — `type:bug`, P2-medium. Body has inline AC prose ("AC: запустить каждый скрипт …") but no `## Acceptance criteria` section. P2 + bug warrants structured AC.
+- [ ] **#17** "Ghostty xterm-ghostty terminfo missing" — `type:bug`. Same pattern: inline `AC:` prose, no header.
+- [ ] **#19** "/feature pipeline: move issue Icebox → In Progress" — `type:feature`, P2-medium, already has `needs-ac` label. Body has one-line acceptance prose; needs structured section.
+- [ ] **#21** "hook: tighten issue-ref regex" — `type:bug`, already labelled `needs-ac`. No structured AC; body is description-only.
+- [ ] **#22** "runbook: replace line-number references" — `type:chore`, already labelled `needs-ac`. Out of strict scope (chore, not feature/bug), but label already applied — keep it.
+- [ ] **#23** "hook: consolidate duplicated -m extraction" — `type:chore`, already labelled `needs-ac`. Same as #22.
+
+```bash
+# Add needs-ac to issues missing the label entirely
+gh issue edit 16 --add-label needs-ac
+gh issue edit 17 --add-label needs-ac
+
+# #19, #21, #22, #23 already carry needs-ac — no label change needed
+gh issue comment 19 --body "Reminder: structured \`## Acceptance criteria\` section still missing. needs-ac label remains."
+gh issue comment 21 --body "Reminder: structured \`## Acceptance criteria\` section still missing. needs-ac label remains."
+```
+
+---
+
+## 3. Stale candidates
+
+**None.** Oldest open issue is 5 days (#6, #7, #10, #12, #16, #17). Threshold is 60 days. Re-run this section in mid-June 2026 at earliest.
+
+However, two structural observations warrant action *now* even though the calendar threshold is not hit:
+
+### 3a. Issue #6: blocker resolved
+
+Issue #6 carries label `blocked` and its body declares `Зависит от "First real feature through full pipeline"` — that parent is **#5**, which closed `2026-04-24` as `completed`. The blocker is gone. The session log it depends on (`docs/runbooks/first-feature-session-log.md`) is now also referenced as evidence in #48. #6 should drop the `blocked` label and become actionable.
+
+```bash
+gh issue edit 6 --remove-label blocked
+gh issue comment 6 --body "Unblocking: parent epic #5 closed 2026-04-24 (completed). Session log \`docs/runbooks/first-feature-session-log.md\` now exists (also cited from #48). Ready for /plan."
+```
+
+### 3b. Epic #44: Phase-0 blocker list contains a closed issue
+
+Epic #44 lists four Phase-0 entry conditions; the first is `#41 CI scope` which **closed 2026-04-24 as completed**. The epic body still presents it as outstanding. Comment to record progress; do not edit the body (read-only protocol).
+
+```bash
+gh issue comment 44 --body "Phase-0 progress: #41 (CI scope) closed 2026-04-24 as completed. Three blockers remain (Codex timeout, /implement branching, Claude verifies side-effects). Epic body should be refreshed at next plan."
+```
+
+---
+
+## 4. Inconsistent labels
+
+### 4a. Conflicting type labels (`enhancement` + `type:*`)
+
+The repo has both a generic GitHub `enhancement` label and a project-specific `type:*` taxonomy. Mixing them is ambiguous.
+
+- **#19** carries `enhancement` AND `type:feature`. Drop `enhancement`; `type:feature` is canonical per CLAUDE.md conventions.
+- **#21** carries `enhancement` AND `type:bug`. The combination is incoherent (same issue cannot be both enhancement and bug). Keep `type:bug` (matches body — "Pre-existing" defect in regex), drop `enhancement`.
+- **#23** carries `enhancement` AND `type:chore`. Pick one; body describes a refactor → `type:chore` is correct, drop `enhancement`.
+- **#22** carries `documentation` AND `type:chore`. `documentation` is the GitHub default label; project taxonomy uses `area:docs`. Drop `documentation` (already has `area:docs`).
+
+```bash
+gh issue edit 19 --remove-label enhancement
+gh issue edit 21 --remove-label enhancement
+gh issue edit 23 --remove-label enhancement
+gh issue edit 22 --remove-label documentation
+```
+
+### 4b. Missing priority on epic and policy items
+
+- **#44** (`Epic: Autonomous Backlog Sweep`) has only `blocked` + `epic`, no `P*` label and no `type:epic` (uses bare `epic` label inconsistent with `type:*` schema seen on #5 which used `type:epic`).
+- **#38** (`Language policy: EN-only`) is `P3-low` despite being scoped across `bootstrap/`, `docs/`, and `CLAUDE.md` — large surface, but cosmetic. P3 is defensible; flag for owner review only.
+
+```bash
+gh issue edit 44 --add-label "P2-medium,type:epic" --remove-label epic
+# Optional, owner judgment:
+# gh issue edit 38 --add-label P2-medium --remove-label P3-low   # only if surface area justifies bump
+```
+
+### 4c. Missing `area:*` on hook items
+
+#21 and #23 already carry `area:hooks`. #19 carries `area:pipeline`. Consistent. No action.
+
+---
+
+## 5. Orphan sub-issues
+
+No formal GitHub sub-issue links exist (the MCP `get_sub_issues` was not necessary — body-level "Blocked by" references are the only parent-child signal in this repo).
+
+Orphan-by-prose:
+- **#6** → parent **#5** is closed. Treated under §3a.
+- **#44** Phase 0 → references **#41** (closed). Treated under §3b.
+
+No other parent-child mismatches detected.
+
+---
+
+## 6. Missing ADR links
+
+Issues labelled `adr-needed` should either have a draft ADR linked or be staged behind one.
+
+- **#31** `adr-needed` — body acceptance criteria explicitly says "An ADR is written and merged documenting the chosen option." No ADR draft path linked yet. This is correct *pre-decision* state (the ADR is the deliverable), but the issue should record once a draft exists. No action now; reminder only.
+- **#32** `adr-needed` — same shape as #31, blocked on it. No ADR yet expected.
+
+Neither has a `decision-needed` or `architecture` label, but both target ADR delivery and are correctly labelled `adr-needed`. No action.
+
+---
+
+## 7. Priority adjustments (additional)
+
+Beyond the conflicts in §4, two priority calls deserve a second look:
+
+- **#16** (`macOS default bash 3.2 incompatible`) is `P2-medium`, `type:bug`, `estimate/3`. It blocks new-machine bootstrap on stock macOS. Either keep P2 or escalate to P1 if anyone bootstraps a fresh mini in the next sprint. Owner judgment.
+- **#10** (`End-to-end validate CI workflow templates`) is `P2-medium`, `estimate/5`. Templates ship in `bootstrap/templates/` but have never been exercised. Untested CI templates qualify as "fiction" by the same standard #12 names for runbooks. Owner judgment whether to keep P2 or hold.
+
+No `gh` action proposed; priorities are owner-controlled.
+
+---
+
+## Summary of proposed `gh` commands
+
+```bash
+# Cross-links
+gh issue comment 21 --body "Related: #23 (sibling hook-hardening item from same /review during #14). Consider bundling into one PR."
+gh issue comment 23 --body "Related: #21 (sibling hook-hardening item from same /review during #14). Consider bundling into one PR."
+
+# Make #31→#32 dependency explicit
+gh issue edit 32 --add-label blocked
+gh issue comment 32 --body "Hard-blocked by #31: orphan-removal policy (Option C) couples to manifest decision. Will revive after #31 ADR merges."
+
+# Acceptance-criteria gaps
+gh issue edit 16 --add-label needs-ac
+gh issue edit 17 --add-label needs-ac
+gh issue comment 19 --body "Reminder: structured \`## Acceptance criteria\` section still missing. needs-ac label remains."
+gh issue comment 21 --body "Reminder: structured \`## Acceptance criteria\` section still missing. needs-ac label remains."
+
+# Unblock #6 (parent #5 closed)
+gh issue edit 6 --remove-label blocked
+gh issue comment 6 --body "Unblocking: parent epic #5 closed 2026-04-24 (completed). Session log \`docs/runbooks/first-feature-session-log.md\` now exists (also cited from #48). Ready for /plan."
+
+# Refresh #44 phase-0 status
+gh issue comment 44 --body "Phase-0 progress: #41 (CI scope) closed 2026-04-24 as completed. Three blockers remain (Codex timeout, /implement branching, Claude verifies side-effects). Epic body should be refreshed at next plan."
+
+# Label hygiene — drop conflicting GitHub-default labels
+gh issue edit 19 --remove-label enhancement
+gh issue edit 21 --remove-label enhancement
+gh issue edit 23 --remove-label enhancement
+gh issue edit 22 --remove-label documentation
+
+# Epic taxonomy consistency
+gh issue edit 44 --add-label "P2-medium,type:epic" --remove-label epic
+```
+
+---
+
+## Notes for the operator
+
+- **No mutations performed.** Read-only analysis.
+- **Assumed labels exist** in the repo: `needs-ac`, `blocked`, `type:epic`, `P2-medium`. If any are absent, `gh label create <name>` first.
+- **Stale-detection threshold (60 days) was not triggered** for any issue. Next groomer run should re-check around **2026-06-20** when the oldest current issues age past 60 days.


### PR DESCRIPTION
## Summary

Adds two `/backlog-review` skill outputs (2026-04-24 and 2026-04-26) to `docs/backlog/` for audit trail. These were generated by the existing `backlog-groomer` agent during weekly reviews and previously lived only in the working tree.

No issue state changes — `backlog-groomer` is read-only by design.

## Why land

- `docs/backlog/` is tracked-domain; orphan reports in working tree drift.
- Pre-dates the `/backlog-grooming` agent work (Refs #142) — useful as historical baseline.

## Test plan

- [x] Conventional Commits + issue ref
- [x] Docs-only, no code changes
- [ ] No CI to break

Refs #142