### PR TITLE
feat(knowledge): anti-patterns.md accumulator + commit-msg reminder #124

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ bootstrap/
 
 **Slash commands (10):** `/plan`, `/implement`, `/adr`, `/review`, `/codex-review`, `/task-to-issue`, `/issue-to-task`, `/backlog-review`, `/project-health`, `/feature` (master orchestrator).
 
-**Hooks (3):** `pre-commit-governance.sh` — блокирует коммиты без CC-префикса / issue-ref / ADR-ref (PreToolUse). `posttooluse-format.sh` — проверяет форматирование и lint после Edit|MultiEdit|Write и выдаёт предупреждение Claude (PostToolUse, не блокирует). `stop-hook.sh` — блокирует завершение сессии если тесты не проходят (Stop); уважает `stop_hook_active` escape-hatch.
+**Hooks (4):** `pre-commit-governance.sh` — блокирует коммиты без CC-префикса / issue-ref / ADR-ref (PreToolUse). `commit-msg-governance.sh` — применяет те же блокирующие правила к прямым терминальным коммитам (git hook); также выдаёт non-blocking reminder если `docs/anti-patterns.md` не трогался на текущей ветке при наличии code-файлов в коммите. `posttooluse-format.sh` — проверяет форматирование и lint после Edit|MultiEdit|Write и выдаёт предупреждение Claude (PostToolUse, не блокирует). `stop-hook.sh` — блокирует завершение сессии если тесты не проходят (Stop); уважает `stop_hook_active` escape-hatch.
 
 **Scripts (5):** `mini-preflight`, `mini-session`, `mini-bootstrap-project`, `mini-health`, `review-codex.sh`.
 
@@ -120,7 +120,7 @@ bootstrap/
 
 **Что обязательно на каждом этапе** — см. `docs/runbooks/feature-pipeline.md#10-pre-pr-artifact-verification`. Пропуск этапа без явного основания блокирует pipeline.
 
-**Механический gate коммитов:** `pre-commit-governance.sh` блокирует коммит без Conventional Commits prefix + issue-ref.
+**Механический gate коммитов:** `pre-commit-governance.sh` (Claude Code PreToolUse) блокирует коммит без Conventional Commits prefix + issue-ref. `commit-msg-governance.sh` (git-level) дополнительно напоминает (non-blocking) обновить `docs/anti-patterns.md`, если в этой ветке не было ни одного коммита с правками этого файла, а в текущем коммите есть code-файлы.
 
 **Механический gate PR:** планируется в issue #115.
 

--- a/bootstrap/hooks/commit-msg-governance.sh
+++ b/bootstrap/hooks/commit-msg-governance.sh
@@ -133,5 +133,34 @@ if [ "$is_decision_change" = "true" ]; then
     fi
 fi
 
+# --- Anti-patterns reminder (non-blocking, exit 0) ---
+# Fires when: (a) staged files include non-docs code (*.sh, *.py, *.bats,
+# bootstrap/) AND (b) docs/anti-patterns.md is not staged in this commit AND
+# (c) docs/anti-patterns.md has not been touched in any commit on this branch
+# since it diverged from origin/main.
+# Scoped to merge-base..HEAD so existing commits on main do not suppress the
+# reminder on a new branch. Falls back to HEAD (all history) when origin/main
+# does not exist (e.g. sandboxed repos in tests).
+all_staged=$(git diff --cached --name-only 2>/dev/null || true)
+staged_code=$(echo "$all_staged" | \
+    grep -v '^docs/' | grep -v '\.md$' | grep -E '\.(sh|py|bats)$|^bootstrap/' || true)
+if echo "$all_staged" | grep -qE '^docs/anti-patterns\.md$'; then
+    ap_staged=yes
+else
+    ap_staged=
+fi
+if [ -n "$staged_code" ] && [ -z "$ap_staged" ] && git rev-parse --verify HEAD >/dev/null 2>&1; then
+    _base=$(git merge-base HEAD origin/main 2>/dev/null || true)
+    if [ -n "$_base" ]; then
+        anti_pattern_commits=$(git log --oneline --max-count=1 "${_base}..HEAD" -- docs/anti-patterns.md 2>/dev/null | wc -l | tr -d '[:space:]')
+    else
+        anti_pattern_commits=$(git log --oneline --max-count=1 HEAD -- docs/anti-patterns.md 2>/dev/null | wc -l | tr -d '[:space:]')
+    fi
+    unset _base
+    if [ "${anti_pattern_commits:-0}" -eq 0 ]; then
+        log "REMINDER: code staged but docs/anti-patterns.md not touched on this branch — consider adding a new entry if you caught a lazy pattern this session"
+    fi
+fi
+
 log "OK: $msg_subject"
 exit 0

--- a/bootstrap/scripts/test-commit-msg-governance.sh
+++ b/bootstrap/scripts/test-commit-msg-governance.sh
@@ -361,11 +361,13 @@ assert_stderr_contains \
 
 # T2: exit code is still 0 (non-blocking)
 run_hook_capture_stderr "fix: patch something (#124)" "$AP_REPO"
-if [ $? -eq 0 ]; then
+_rc=$?
+if [ "$_rc" -eq 0 ]; then
     pass "AP-T2: reminder is non-blocking (exit 0)"
 else
     fail "AP-T2: expected exit 0, reminder must not block"
 fi
+unset _rc
 
 # T3: docs/anti-patterns.md also staged → no reminder
 mkdir -p "$AP_REPO/docs"

--- a/bootstrap/scripts/test-commit-msg-governance.sh
+++ b/bootstrap/scripts/test-commit-msg-governance.sh
@@ -12,7 +12,11 @@
 
 set -uo pipefail
 
-HOOK="${1:-$(dirname "$0")/../../bootstrap/hooks/commit-msg-governance.sh}"
+# Canonicalize to absolute path so cd into sandbox repos doesn't break the
+# hook invocation (relative paths resolve against the current directory).
+_hook_default="$(cd "$(dirname "$0")/../.." && pwd)/bootstrap/hooks/commit-msg-governance.sh"
+HOOK="${1:-$_hook_default}"
+unset _hook_default
 # Fall back to installed location
 if [ ! -f "$HOOK" ]; then
     HOOK="$HOME/.claude/git-hooks/commit-msg"
@@ -292,6 +296,131 @@ else
         fail "HTR-bad: expected exit 2 when staged hook missing, got exit $rc"
     fi
 fi
+
+echo ""
+
+# ===== ANTI-PATTERNS REMINDER =====
+# Tests for the non-blocking reminder that fires when code is staged but
+# docs/anti-patterns.md has never been touched on the current HEAD.
+echo "Anti-patterns reminder (non-blocking)"
+
+# Helper: run hook, capture stderr, return exit code via global AP_STDERR
+AP_STDERR=""
+run_hook_capture_stderr() {
+    local msg="$1"
+    local repo="${2:-$TMPDIR_REPO}"
+    local msg_file stderr_file
+    msg_file=$(mktemp)
+    stderr_file=$(mktemp)
+    echo "$msg" > "$msg_file"
+    (cd "$repo" && "$HOOK" "$msg_file") 2>"$stderr_file"
+    local rc=$?
+    AP_STDERR=$(cat "$stderr_file")
+    rm -f "$msg_file" "$stderr_file"
+    return $rc
+}
+
+assert_stderr_contains() {
+    local label="$1"
+    local pattern="$2"
+    if echo "$AP_STDERR" | grep -qF "$pattern"; then
+        pass "$label — stderr contains expected pattern"
+    else
+        fail "$label — expected stderr to contain '$pattern'; got: $AP_STDERR"
+    fi
+}
+
+assert_stderr_lacks() {
+    local label="$1"
+    local pattern="$2"
+    if echo "$AP_STDERR" | grep -qF "$pattern"; then
+        fail "$label — expected stderr NOT to contain '$pattern'; got: $AP_STDERR"
+    else
+        pass "$label — stderr correctly lacks '$pattern'"
+    fi
+}
+
+# Sandboxed repo for reminder tests — no prior commits touching anti-patterns.md
+AP_REPO=$(mktemp -d /tmp/claude-mini-ap-reminder-test-XXXXXX)
+trap 'rm -rf "$TMPDIR_REPO" "$TMPDIR_HOME" "$TMPDIR_REPO2" "$AP_REPO"' EXIT
+git -C "$AP_REPO" init -q
+git -C "$AP_REPO" symbolic-ref HEAD refs/heads/feat/ap-124
+export GIT_CONFIG_GLOBAL="$TMPDIR_HOME/.gitconfig"
+# Initial commit (README only — not touching anti-patterns.md)
+echo "readme" > "$AP_REPO/README.md"
+git -C "$AP_REPO" add README.md
+GIT_DIR="$AP_REPO/.git" GIT_WORK_TREE="$AP_REPO" git commit -q -m "chore: initial (#0)"
+
+# T1: code staged, anti-patterns.md never touched on HEAD → reminder fires
+echo "fix-something.sh" > "$AP_REPO/fix-something.sh"
+git -C "$AP_REPO" add fix-something.sh
+run_hook_capture_stderr "fix: patch something (#124)" "$AP_REPO"
+assert_stderr_contains \
+    "AP-T1: reminder fires when .sh staged and anti-patterns.md untouched" \
+    "REMINDER"
+
+# T2: exit code is still 0 (non-blocking)
+run_hook_capture_stderr "fix: patch something (#124)" "$AP_REPO"
+if [ $? -eq 0 ]; then
+    pass "AP-T2: reminder is non-blocking (exit 0)"
+else
+    fail "AP-T2: expected exit 0, reminder must not block"
+fi
+
+# T3: docs/anti-patterns.md also staged → no reminder
+mkdir -p "$AP_REPO/docs"
+echo "# Anti-patterns" > "$AP_REPO/docs/anti-patterns.md"
+git -C "$AP_REPO" add docs/anti-patterns.md
+run_hook_capture_stderr "fix: patch something (#124)" "$AP_REPO"
+assert_stderr_lacks \
+    "AP-T3: no reminder when docs/anti-patterns.md is staged" \
+    "REMINDER"
+git -C "$AP_REPO" restore --staged docs/anti-patterns.md 2>/dev/null || true
+
+# T4: anti-patterns.md previously committed on HEAD → no reminder
+GIT_DIR="$AP_REPO/.git" GIT_WORK_TREE="$AP_REPO" git add docs/anti-patterns.md
+GIT_DIR="$AP_REPO/.git" GIT_WORK_TREE="$AP_REPO" git commit -q -m "docs: seed anti-patterns (#124)"
+echo "another-fix.sh" > "$AP_REPO/another-fix.sh"
+git -C "$AP_REPO" add another-fix.sh
+run_hook_capture_stderr "fix: another fix (#124)" "$AP_REPO"
+assert_stderr_lacks \
+    "AP-T4: no reminder after anti-patterns.md committed on HEAD" \
+    "REMINDER"
+
+# T5: docs-only staged (*.md in docs/) → no reminder
+git -C "$AP_REPO" restore --staged . 2>/dev/null || true
+echo "# updated" >> "$AP_REPO/README.md"
+git -C "$AP_REPO" add README.md
+run_hook_capture_stderr "docs: update readme (#124)" "$AP_REPO"
+assert_stderr_lacks \
+    "AP-T5: no reminder for docs-only commit (no code files staged)" \
+    "REMINDER"
+
+# T6: anti-patterns.md committed on main but NOT on current branch → reminder fires
+# (validates that merge-base scoping works — prior commits on main must not suppress)
+AP_REPO2=$(mktemp -d /tmp/claude-mini-ap-reminder-t6-XXXXXX)
+trap 'rm -rf "$TMPDIR_REPO" "$TMPDIR_HOME" "$TMPDIR_REPO2" "$AP_REPO" "$AP_REPO2"' EXIT
+git -C "$AP_REPO2" init -q
+export GIT_CONFIG_GLOBAL="$TMPDIR_HOME/.gitconfig"
+git -C "$AP_REPO2" symbolic-ref HEAD refs/heads/main
+# Seed docs/anti-patterns.md on main
+mkdir -p "$AP_REPO2/docs"
+echo "# Anti-patterns" > "$AP_REPO2/docs/anti-patterns.md"
+git -C "$AP_REPO2" add docs/anti-patterns.md
+GIT_DIR="$AP_REPO2/.git" GIT_WORK_TREE="$AP_REPO2" git commit -q -m "docs: seed anti-patterns on main (#0)"
+# Branch off — new branch has no AP commits of its own
+git -C "$AP_REPO2" update-ref refs/heads/feat/new-feature refs/heads/main
+git -C "$AP_REPO2" symbolic-ref HEAD refs/heads/feat/new-feature
+# Set refs/remotes/origin/main directly — avoids fetching from a non-bare repo
+# (fetching from self is unreliable; direct update-ref is deterministic)
+git -C "$AP_REPO2" update-ref refs/remotes/origin/main refs/heads/main
+# Stage a code file without anti-patterns.md
+echo "fix.sh" > "$AP_REPO2/fix.sh"
+git -C "$AP_REPO2" add fix.sh
+run_hook_capture_stderr "fix: something (#124)" "$AP_REPO2"
+assert_stderr_contains \
+    "AP-T6: reminder fires on branch even when anti-patterns.md committed on main" \
+    "REMINDER"
 
 echo ""
 

--- a/docs/anti-patterns.md
+++ b/docs/anti-patterns.md
@@ -1,38 +1,192 @@
 # Anti-patterns
 
-Накопленный реестр ленивых решений, которые LLM воспроизводит повторно. Каждый паттерн — одна запись. Источник записей — реактивные пинки оператора (Принцип 4).
+Накопленный реестр ленивых решений, которые LLM воспроизводит повторно.
+Источник записей — реактивные пинки оператора (Принцип 4).
 
-**Формат записи:**
+**Как добавить запись:** при каждом manual catch — добавить строку в Ranked summary и раздел ниже в том же коммите. `commit-msg-governance.sh` напоминает об этом если коммит содержит code-файлы, а файл не трогался на ветке. Формат: заполни все шесть полей (Pattern, Frequency, Severity, Detectability, Detector, Example, Fix); выставь Score по формуле; пересортируй Ranked summary по убыванию Score.
 
-```
-## YYYY-MM-DD — <название паттерна>
-
-**Симптом:** что оператор увидел в артефакте.
-**Корень:** почему LLM так поступает.
-**Как блокировать:** конкретный gate, формулировка в prompt, или правило в /review.
-**Ссылка:** issue/ADR/PR, где паттерн был пойман впервые.
-```
+*Будущий adversarial-critic (synthesis ticket, ещё не реализован) загрузит этот файл в context автоматически. До его появления используй как checklist при ручной проверке.*
 
 ---
 
-## 2026-04-30 — TODO без тикета
+## Scoring rubric
 
-**Симптом:** LLM оставляет `# TODO: ...` или `# FIXME: ...` в коммите без ссылки на issue.
+Each field is an integer **1–5**, assigned by the operator at time of entry:
 
-**Корень:** Дефолтное поведение — отложить непонятное без создания трекинга. Следующая сессия не увидит этот TODO, потому что контекст потерян.
+| Field | 1 | 3 | 5 |
+|---|---|---|---|
+| **Frequency** | Seen once | Seen 2–4× | Seen 5+ times or in every sprint |
+| **Severity** | Cosmetic, caught immediately | Needs rework, passed initial review | Would reach production undetected |
+| **Detectability** | Caught by deterministic gate | Requires LLM critic | Requires human re-read or escapes all gates |
 
-**Как блокировать:** semgrep-правило `llm-todo-without-ticket` (слой 1 `/review`). Правило: `bootstrap/templates/.semgrep/llm-antipatterns.yaml#llm-todo-without-ticket`. Требует наличия `#NNN` или URL в той же строке.
-
-**Ссылка:** issue #121, ADR-0023.
+**Score = Frequency × 2 + Severity × 2 + Detectability**  
+Maximum score = 25. Patterns are listed in descending score order.
 
 ---
 
-## 2026-04-30 — Закомментированный блок кода
+## Ranked summary
 
-**Симптом:** LLM коммитит 5+ подряд идущих строк комментариев — часто это закомментированный старый код вместо его удаления.
+| # | Pattern | Freq | Sev | Det | Score |
+|---|---|---|---|---|---|
+| 1 | `truncated-file` | 4 | 5 | 4 | **22** |
+| 2 | `symptom-fix-not-root` | 4 | 4 | 4 | **20** |
+| 3 | `narrow-special-case` | 3 | 4 | 4 | **18** |
+| 4 | `adr-drift` | 3 | 4 | 3 | **17** |
+| 5 | `hedging-in-plan` | 4 | 3 | 3 | **17** |
+| 6 | `todo-without-ticket` | 5 | 2 | 1 | **15** |
+| 7 | `commented-block` | 4 | 2 | 1 | **13** |
 
-**Корень:** LLM предпочитает сохранить "на всякий случай" вместо чистого удаления. Это мусор в кодовой базе — следующий читатель не знает, актуален ли этот код.
+---
 
-**Как блокировать:** semgrep-правило `llm-commented-block` (слой 1 `/review`). Правило: `bootstrap/templates/.semgrep/llm-antipatterns.yaml#llm-commented-block`. Порог: 5+ последовательных строк с `#`. Внимание: rule имеет известный false-positive на многострочные документационные комментарии — нужно тюнить через per-file disable.
+## Pattern entries
 
-**Ссылка:** issue #121, ADR-0023.
+---
+
+### truncated-file
+
+**Frequency:** 4 | **Severity:** 5 | **Detectability:** 4 | **Score:** 22
+
+**Detector:** Read the file immediately after Write/Edit. If file is shorter than
+expected or ends abruptly, flag. Adversarial-critic checks for files < 10 lines
+where the plan implied 30+. No deterministic gate catches this reliably.
+
+**Example:**  
+Plan says "write complete bootstrap/hooks/stop-hook.sh with 6 test cases."
+Model writes the file, 8 lines, ends at `set -uo pipefail`. Claims "done."
+Caught by reading the file post-write; model had hit a context limit mid-output
+and silently stopped.
+
+**Fix:**  
+After every Write/Edit, Read the file back. Assert line count is plausible.
+If truncated: re-issue the Write with explicit instruction "write the COMPLETE
+file, do not truncate." Root cause: context window pressure causes silent
+truncation; model does not signal this.
+
+---
+
+### symptom-fix-not-root
+
+**Frequency:** 4 | **Severity:** 4 | **Detectability:** 4 | **Score:** 20
+
+**Detector:** Adversarial-critic with explicit instruction: "does this fix address
+the root cause or only the observable symptom?" No deterministic gate.
+
+**Example:**  
+Hook fails on empty stdin with "jq: null". Fix: add `|| true` to silence the
+error. Root cause: caller passes empty string, not empty JSON object. Correct
+fix: validate stdin before parsing, return early with log message.
+Symptom fix would pass all tests; root cause fix prevents the class of errors.
+
+**Fix:**  
+Before writing the fix, ask: "what input condition causes this?" Change the
+condition, not the output. Add a test that reproduces the root cause input.
+
+---
+
+### narrow-special-case
+
+**Frequency:** 3 | **Severity:** 4 | **Detectability:** 4 | **Score:** 18
+
+**Detector:** Adversarial-critic: "does this implementation handle only the example
+input or the general case?" Property-based tests (Hypothesis) surface this.
+
+**Example:**  
+Plan: "parse commit message to extract issue reference." Implementation uses
+`grep -E '#[0-9]+'` on the first line only. All AC examples have the issue ref
+in the subject. Test passes. Body-only refs (multi-line messages) silently fail.
+Caught when a real commit with `Closes #9` in the body was incorrectly blocked.
+
+**Fix:**  
+Read the full message, not just the subject. Write property-based tests that
+generate messages with refs in all valid positions. Adversarial-critic prompt
+must include "test with ref in body, not just subject."
+
+---
+
+### adr-drift
+
+**Frequency:** 3 | **Severity:** 4 | **Detectability:** 3 | **Score:** 17
+
+**Detector:** adr-reviewer agent compares implementation diff against the merged
+ADR. But this fires only if adr-reviewer is invoked — it is not automatic.
+Pre-commit hook (Rule 3) enforces ADR reference on decision-type staged changes
+but does not verify implementation matches ADR content.
+
+**Example:**  
+ADR-0011 specifies `exit 1` for denied commits. Implementation uses `exit 2`
+(JSON output pattern from PostToolUse hook, copied from wrong template).
+Both exit codes block the commit; test passes; drift is invisible until a
+consumer checks the exit code explicitly.
+
+**Fix:**  
+After /implement, run adr-reviewer against every ADR referenced in the plan.
+Assert each §Decision Outcome constraint is satisfied in the diff.
+Root cause: model copies from the most recent similar file rather than reading
+the ADR that governs the current context.
+
+---
+
+### hedging-in-plan
+
+**Frequency:** 4 | **Severity:** 3 | **Detectability:** 3 | **Score:** 17
+
+**Detector:** `advisor()` pre-check (Principle 1 mandate). No current
+deterministic gate — `lint-prompts.sh` only checks `bootstrap/agents/`,
+`bootstrap/commands/`, `bootstrap/skills/` and does not scan `plan.md`.
+A future `lint-prompts.sh` extension for `plan.md` hedging terms would
+lower Detectability to 1.
+
+**Example:**  
+plan.md §4: "The hook could use either `exit 0` or `exit 1` depending on
+context." No decision is made. /implement picks exit 0 arbitrarily. Caught
+at /review when reviewer asks "which did you choose and why?"
+
+**Fix:**  
+Principle 1: no sentence in plan.md ends without a decision. Replace every
+"could/might" with either "(a) correct choice + rationale" or "(b) `not known
+— empirical test needed: <describe test>`." Advisor flags this during
+plan pre-check; fix plan.md before /implement.
+
+---
+
+### todo-without-ticket
+
+**Frequency:** 5 | **Severity:** 2 | **Detectability:** 1 | **Score:** 15
+
+**Detector:** semgrep rule `llm-todo-without-ticket`
+(`bootstrap/templates/.semgrep/llm-antipatterns.yaml`). Fires on `TODO` or
+`FIXME` without `#NNN` or a URL on the same line. Deterministic gate, layer 1
+of /review.
+
+**Example:**  
+`# TODO: handle edge case where stdin is empty` committed without issue ref.
+Next session has no trace of this. The edge case is never handled.
+
+**Fix:**  
+Every TODO in committed code must reference an issue: `# TODO(#124): handle
+edge case`. If no issue exists, create one first. Semgrep gate blocks commit
+if rule fires.
+
+---
+
+### commented-block
+
+**Frequency:** 4 | **Severity:** 2 | **Detectability:** 1 | **Score:** 13
+
+**Detector:** semgrep rule `llm-commented-block`
+(`bootstrap/templates/.semgrep/llm-antipatterns.yaml`). Fires on 5+ consecutive
+lines starting with `#`. Known false-positive on multi-line documentation
+blocks — can be suppressed per-file with `# nosemgrep`. Deterministic gate,
+layer 1 of /review.
+
+**Example:**  
+Old implementation of a hook section left in as a comment "for reference."
+Six lines, preceded by the new implementation. No indication of why it's kept.
+Committed as-is. Reader cannot tell if the commented block is intentional
+backup or forgotten cleanup.
+
+**Fix:**  
+Delete commented-out code. If it matters, it's in git history. If keeping it
+is intentional (e.g., disabled-by-design escape hatch), replace with a single
+explanatory comment: `# Disabled: <reason> (re-enable via <condition>)`.
+Root cause: model defaults to preservation over deletion under uncertainty.


### PR DESCRIPTION
## Summary

- Migrate `docs/anti-patterns.md` from narrative format to structured table schema (Pattern / Frequency / Severity / Detectability / Score / Detector / Example / Fix) with ranked summary sorted by `Score = Freq×2 + Sev×2 + Det`. Seeds 7 entries from the last 8 days of work.
- Add non-blocking reminder to `commit-msg-governance.sh`: fires (stderr only, exit 0) when code files are staged and `docs/anti-patterns.md` has not been touched on the current branch since `merge-base` with `origin/main`. Scoped to branch history so existing main commits do not suppress the nudge.
- Update README inventory from Hooks (3) to Hooks (4) with accurate `commit-msg-governance.sh` description.
- Drive-by fix: canonicalise `HOOK` path to absolute in test harness (`test-commit-msg-governance.sh`) — relative path caused all pass-case assertions to silently misfire when cwd changed to sandbox repos.

## Review findings resolved

**From /review (Claude + security/reliability/docs agents):**
- BLOCK: `git log HEAD --` counted all of main's history → reminder permanently dead. Fixed to `merge-base origin/main..HEAD` with fallback to HEAD for repos without a remote.
- BLOCK: `hedging-in-plan` Detector falsely claimed `lint-prompts.sh` scans plan.md for hedging terms. Corrected — no deterministic gate exists yet; advisor() is the operative detector.
- BLOCK: `adversarial-critic (ticket #6)` reference was false — agent not yet implemented. Replaced with accurate note.
- BLOCK: README showed Hooks (3) while introducing a 4th hook with non-trivial behaviour. Fixed.
- SUGGEST: SC2015 `grep -qF ... && echo "yes" || true` → `if/then/else` per project policy.
- SUGGEST: `grep -qF "docs/anti-patterns.md"` → anchored `grep -qE '^docs/anti-patterns\.md$'`.
- SUGGEST: `--max-count=1` added to `git log` (O(1) in history depth).

**From /codex-review (Codex):**
- BLOCK: unborn HEAD guard missing — `git log HEAD` on initial commit exits 128. Added `git rev-parse --verify HEAD` guard.
- BLOCK: T6 test used non-bare self-fetch (unreliable). Fixed to `git update-ref refs/remotes/origin/main` directly.
- SUGGEST: `tr -d ' '` → `tr -d '[:space:]'` (robust against wc implementations that pad with tabs).
- NIT: duplicate rank 4 in scored summary. Fixed.
- NIT: README wording "дублирует те же правила" implied reminder was another enforcement rule. Clarified.

## Known gaps (not blocking)

- AC#4 ("adversarial-critic loads this file in context") is deferred to the adversarial-critic implementation ticket. The file format (Markdown table) is intentionally stable for that integration.
- Code-file detection filter covers `.sh/.py/.bats` and `bootstrap/` paths only — `.ts/.go/.rs` not included. Acceptable for this shell-only project; extend when languages are added.
- Operators with existing `~/.claude/git-hooks/commit-msg` copies will not get the reminder until they re-run `./bootstrap/universal-setup.sh --hook-this-repo --force` (per ADR-0011 drift class).
- `docs/domain/overview.md` Interface Contracts table for `commit-msg-governance.sh` does not yet mention the reminder behavior. Follow-up pass.

## QA

**Tests:** All changed logic paths covered. 37/37 tests pass (`test-commit-msg-governance.sh`). AP-T1…AP-T6 cover all reminder branches including merge-base scoping (T6), suppression when file is staged (T3), suppression after prior branch commit (T4), docs-only commit (T5). Full regression: Rules 1–3, Special Cases, HTR installer tests unaffected.

**ShellCheck** (`-S error`): `commit-msg-governance.sh` and `test-commit-msg-governance.sh` both clean.

**Docs:** README updated. `docs/anti-patterns.md` scoring and Detector fields verified accurate. CLAUDE.md description of anti-patterns.md remains accurate.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)