### PR TITLE
feat(critic): adversarial-critic agent with explicit lazy-mandate #123

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,7 @@ Closes #
 - [ ] Domain docs обновлены (если граница BC изменилась)
 - [ ] Тесты: unit / integration; coverage ≥ floor
 - [ ] `/review` прошёл
+- [ ] `adversarial-critic` запущен; BLOCK-findings устранены (или задокументированы как осознанный компромисс)
 - [ ] `/codex-review` прошёл (или `type:deferred-review` issue открыт)
 - [ ] Разногласия между ревьюерами разрешены
 - [ ] Security scans clean

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@
 | после `/implement` | `domain-reviewer` | если `docs/domain/` изменялся |
 | внутри `/review` | `security-reviewer`, `reliability-reviewer` | prod-bound: `bootstrap/`, `.github/workflows/`, `.git/hooks/`, или label `prod-bound` |
 | внутри `/review` | `docs-reviewer` | PR затрагивает `docs/runbooks/`, `docs/architecture/`, `docs/principles.md`, `README.md` — и НЕ только `docs/decisions/` или `docs/domain/` |
+| внутри `/review` (всегда, после Layer 1) | `adversarial-critic` | каждый PR; передать diff как context; BLOCK-findings блокируют merge |
 | еженедельно | `backlog-groomer` | **out-of-band**, не входит в pipeline |
 
 **Оркестратор одной кнопкой:** `/feature <issue-number>` — ведёт по всем стадиям через TodoWrite.
@@ -61,6 +62,7 @@ Read-only критики. Вызов: `@agent-<name>`.
 | `security-reviewer` | Перед prod-значимым PR — затрагивает `bootstrap/`, `.github/workflows/`, `.git/hooks/`, или label `prod-bound` |
 | `reliability-reviewer` | Перед prod-значимым PR (те же условия, что `security-reviewer`) — проверяет idempotency, recoverability, fault tolerance, observability, auditability, resilience |
 | `docs-reviewer` | Внутри `/review`, если PR меняет human-facing docs (`docs/runbooks/`, `docs/architecture/`, `docs/principles.md`, `README.md`) — проверяет читаемость для новичка, исполняемость примеров, отсутствие orphaned sections |
+| `adversarial-critic` | Внутри `/review` всегда (после Layer 1) — ловит ленивые паттерны LLM: дублирование, symptom-fix, narrow-case, copy-paste, truncated-file, magic constants, TODO-без-тикета, commented-out code; загружает `docs/anti-patterns.md` в context |
 
 ## MCP tooling
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ bootstrap/
 
 ## Что внутри
 
-**Агенты (8):** `adr-reviewer`, `domain-reviewer`, `domain-researcher`, `solutions-architect`, `backlog-groomer`, `security-reviewer`, `docs-reviewer`, `reliability-reviewer`.
+**Агенты (9):** `adr-reviewer`, `domain-reviewer`, `domain-researcher`, `solutions-architect`, `backlog-groomer`, `security-reviewer`, `docs-reviewer`, `reliability-reviewer`, `adversarial-critic`.
 
 **Skills (3):** `adr-author` (MADR 4.0), `domain-discovery` (Event Storming), `project-bootstrap` (новый репо со всей обвязкой).
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ bootstrap/
 
 ## Что внутри
 
-**Агенты (9):** `adr-reviewer`, `domain-reviewer`, `domain-researcher`, `solutions-architect`, `backlog-groomer`, `security-reviewer`, `docs-reviewer`, `reliability-reviewer`, `adversarial-critic`.
+**Агенты (9):** `adr-reviewer`, `domain-reviewer`, `domain-researcher`, `solutions-architect`, `backlog-groomer`, `security-reviewer`, `docs-reviewer`, `reliability-reviewer`, `adversarial-critic` (LLM-laziness scanner, всегда в `/review`).
 
 **Skills (3):** `adr-author` (MADR 4.0), `domain-discovery` (Event Storming), `project-bootstrap` (новый репо со всей обвязкой).
 

--- a/bootstrap/agents/adversarial-critic.md
+++ b/bootstrap/agents/adversarial-critic.md
@@ -1,0 +1,79 @@
+---
+name: adversarial-critic
+description: Read-only lazy-pattern detector for PRs. Checks LLM anti-patterns: duplicate code, symptom-fix, narrow special-case, copy-paste, truncated files, magic constants, TODO-without-ticket, commented-out code. Loads docs/anti-patterns.md. Invoked inside /review after deterministic gates pass. NEVER writes files.
+tools: Read, Glob, Grep
+model: sonnet
+color: yellow
+---
+
+You detect lazy LLM implementation patterns in diffs. You read the diff passed in conversation context and `docs/anti-patterns.md`. You write no files. You return findings only.
+
+## Protocol
+
+1. Read `docs/anti-patterns.md` in full. If the file is missing or empty, continue scanning all eight classes and use `unlisted` for all anti-pattern-ref fields; note "registry unavailable" in the report.
+2. Read any files the operator references (plan.md, specific source files). Do not run `git diff` — you have no Bash tool. The operator passes the diff as conversation context.
+3. Scan the diff for each of the eight pattern classes below.
+4. Cross-reference every finding against the `docs/anti-patterns.md` ranked registry. Use the registry slug when matched; use `unlisted` for patterns not yet in the registry.
+5. Return the structured report.
+
+## Pattern classes (scan all eight)
+
+### 1. duplicate-code
+Same logic in ≥ 2 places without a shared abstraction. Flag when a function, condition, or loop body appears verbatim or near-verbatim in two or more locations in the diff.
+
+### 2. symptom-fix-not-root
+The fix silences an observable error without addressing the input condition that causes it. Signal: `|| true`, swallowed exception, default return that masks failure. Ask: does the fix change what input the system receives, or only how the error looks?
+
+### 3. narrow-special-case
+The implementation handles only the example from the acceptance criteria, not the general case. Signal: hardcoded literal matching the AC example, one-element list assumption, single-path handling where the spec implies multiple.
+
+### 4. copy-paste-adjacent-hunk
+Code is copied from an adjacent diff hunk with minimal modification (variable rename, string change). Signal: structural identity between two added blocks; similar line lengths; same control-flow pattern with only surface-level differences.
+
+### 5. truncated-file
+A file is shorter than the plan implies. Signal: file ends abruptly, missing closing brace/function, fewer lines than the plan's stated intent. Flag when the diff writes a file and the result has < 10 lines where the plan described > 30 lines of behavior.
+
+### 6. magic-constant
+A numeric or string literal appears without a named constant and without an inline comment explaining the value. Exempt: 0, 1, -1, empty string, and any value explained by a comment on the same line.
+
+### 7. todo-without-ticket
+A `TODO`, `FIXME`, or `HACK` comment in committed code without a `#NNN` issue reference on the same line. The semgrep gate in Layer 1 catches many of these; flag any survivors in free text or doc strings.
+
+### 8. commented-out-code
+Five or more consecutive lines starting with a comment character (`#`, `//`, `*`) that contain what appears to be executable code rather than documentation. Exempt: explicitly labelled disabled-by-design sections with a reason comment.
+
+## Severity rules
+
+- **BLOCK** — objective, unambiguous: a literal commented-out block with no explanation; a literal hardcoded value with no justification; a TODO with no ticket ref.
+- **SUGGEST** — probable lazy pattern that needs operator judgment: suspected symptom-fix, narrow-case, copy-paste.
+- **NIT** — borderline; would not block if operator disagrees.
+
+Verdict is APPROVE only if zero BLOCK findings.
+
+## Output format
+
+```markdown
+# Adversarial critique
+
+**Verdict:** APPROVE | BLOCK
+
+**Diff reviewed:** {file count} files, {line count} lines added
+
+## Findings
+
+- [BLOCK] file.sh:42 | symptom-fix-not-root | `|| true` after jq parse silences failure without fixing input
+- [SUGGEST] lib.py:17 | narrow-special-case | handles only single-element list; spec implies arbitrary length
+- [NIT] hook.sh:88 | unlisted | variable reused across two unrelated contexts — not a registry pattern
+
+## No findings
+
+If no patterns detected: `No lazy-pattern findings. Diff reviewed against all eight classes.`
+```
+
+## Hard rules
+
+- You do NOT approve a diff with any BLOCK finding.
+- You do NOT write files. Findings are reported only.
+- You DO scan all eight pattern classes even on small diffs — "N/A" is only valid when the diff cannot logically contain the pattern (e.g., a pure documentation change cannot contain magic constants).
+- You DO load `docs/anti-patterns.md` before scanning. The registry provides slug references for cross-referencing findings. Scan scope is the eight classes defined above — registry entries outside those classes are context only, not additional scan targets.
+- You DO flag plan divergence as SUGGEST when you have plan.md context and the diff does not match the stated approach.

--- a/bootstrap/commands/feature.md
+++ b/bootstrap/commands/feature.md
@@ -87,6 +87,10 @@ You are an **orchestrator**, not an executor. You do not run `/plan`, `/implemen
 [ ]    7b. Only if PR touches human-facing docs (docs/runbooks/, docs/architecture/,
 [ ]        docs/principles.md, README.md) — and not exclusively docs/decisions/ or docs/domain/:
 [ ]        invoke @agent-docs-reviewer inside this review phase
+[ ]    7c. Always (after Layer 1 passes): invoke @agent-adversarial-critic — pass the diff
+[ ]        as context; wait for verdict; BLOCK findings must be resolved before merge
+[ ]        If agent unavailable (not installed): document in PR thread as graceful-degradation;
+[ ]        run ./bootstrap/universal-setup.sh --install to restore
 [ ] 8. Run /codex-review
 [ ] 9. Resolve findings; decide on disagreements
 [ ] 10. git commit (governance hook checks)

--- a/bootstrap/commands/review.md
+++ b/bootstrap/commands/review.md
@@ -47,6 +47,20 @@ Review the diff against the plan, principles, and domain contracts. Return markd
 - **SUGGEST** — improve if trivial, else note in PR
 - **NIT** — optional
 
+## Layer 3 — Adversarial critique (always, after Layer 1)
+
+After Layer 1 passes, the operator invokes `@agent-adversarial-critic` and passes the diff as context. Layer 3 runs independently of Layer 2 — its findings are available as input when Layer 2 executes.
+
+The adversarial-critic scans for LLM lazy patterns (duplicate code, symptom-fix, narrow special-case, copy-paste, truncated files, magic constants, TODO-without-ticket, commented-out code). It loads `docs/anti-patterns.md` at startup. Its findings feed into the `claude_review` artifact — they are not a separate review voice.
+
+**Gate rule:** A BLOCK finding from adversarial-critic must be resolved before merge OR explicitly documented as a conscious compromise in the PR thread (operator signs off, explains why). This mirrors the DoD wording in `docs/principles.md`.
+
+**Sanity check:** Verify that the agent's `**Diff reviewed:** N files, M lines added` matches the actual PR. An APPROVE on an empty or partial diff is not a valid approval.
+
+**Failure handling:** If invocation fails (model error, context overflow) or `docs/anti-patterns.md` is unavailable, re-invoke. If failure persists, document in PR thread as graceful-degradation (analogous to `/codex-review` skip): `adversarial-critic skipped — <reason>`. This does not substitute for a passing review.
+
+**Audit trail:** Append the adversarial-critic findings section verbatim into the `claude_review` artifact (or PR thread), even when verdict is APPROVE, so the scan is visible to future readers.
+
 ## Hard rules
 
 - You do NOT approve "LGTM" without an actual scan. Empty findings is only valid if nothing found AFTER full scan.

--- a/docs/anti-patterns.md
+++ b/docs/anti-patterns.md
@@ -5,7 +5,7 @@
 
 **Как добавить запись:** при каждом manual catch — добавить строку в Ranked summary и раздел ниже в том же коммите. `commit-msg-governance.sh` напоминает об этом если коммит содержит code-файлы, а файл не трогался на ветке. Формат: заполни все шесть полей (Pattern, Frequency, Severity, Detectability, Detector, Example, Fix); выставь Score по формуле; пересортируй Ranked summary по убыванию Score.
 
-*Будущий adversarial-critic (synthesis ticket, ещё не реализован) загрузит этот файл в context автоматически. До его появления используй как checklist при ручной проверке.*
+*`adversarial-critic` (`bootstrap/agents/adversarial-critic.md`, issue #123) загружает этот файл в context автоматически при каждом `/review`.*
 
 ---
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -27,10 +27,10 @@
 │                   /task-to-issue  /issue-to-task  /backlog-review       │
 │                   /project-health  /feature (master orchestrator)       │
 │                                                                          │
-│  Agents (8):                                                            │
+│  Agents (9):                                                            │
 │     adr-reviewer        domain-reviewer        domain-researcher        │
 │     solutions-architect backlog-groomer        security-reviewer        │
-│     docs-reviewer       reliability-reviewer                            │
+│     docs-reviewer       reliability-reviewer   adversarial-critic       │
 │                                                                          │
 │  Skills (3, author tools):                                              │
 │     adr-author   domain-discovery   project-bootstrap                   │

--- a/docs/domain/overview.md
+++ b/docs/domain/overview.md
@@ -178,7 +178,7 @@ BC-wide flat table (not per-aggregate). Policy trigger ownership follows the own
 | `ADRDrafted` | FeatureRun | Invoke `adr-reviewer` |
 | PR contains prod-bound change | FeatureRun | Invoke `security-reviewer` and `reliability-reviewer` inside `/review` phase |
 | PR touches human-facing docs (`docs/runbooks/`, `docs/architecture/`, `docs/principles.md`, `README.md`) | FeatureRun | Invoke `docs-reviewer` inside `/review` phase |
-| Layer 1 passes on any `/review` invocation | FeatureRun | Invoke `adversarial-critic` (unconditional); findings are context for `claude_review` ReviewArtifact, not a new artifact type |
+| Layer 1 Gate passes on any `/review` invocation | FeatureRun | Invoke `adversarial-critic` (unconditional); findings are context for `claude_review` ReviewArtifact, not a new artifact type |
 | `TwoVoiceDisagreed` and unresolved at PR time | TwoVoiceReview | Create deferred-review issue (`type:deferred-review`) |
 | `CommitAttempted` without issue-ref | GovernanceRun | `GovernanceBlocked` |
 | `CommitAttempted` on ADR-significant change without ADR-link | GovernanceRun | `GovernanceBlocked` |

--- a/docs/domain/overview.md
+++ b/docs/domain/overview.md
@@ -35,7 +35,7 @@ This BC owns the workflow choreography for AI-assisted software development: pip
 | **Operator** | Human running Claude Code; sole final decision-maker and author of production code | Full write, merge, approve |
 | **Main Loop** (Sonnet) | Orchestrates all pipeline actions under operator direction | Write authority within repo |
 | **Advisor** (Opus) | Consulted via `advisor()` before substantive work and before declaring done; two calls minimum on nontrivial tasks | Read-only; returns critique, not edits |
-| **Read-only Critic** (subagent) | `adr-reviewer`, `domain-reviewer`, `security-reviewer`, `reliability-reviewer`, `backlog-groomer`, `docs-reviewer` — evaluate artifacts, return markdown reports | Read-only; never writes to filesystem or mutates GitHub |
+| **Read-only Critic** (subagent) | `adr-reviewer`, `domain-reviewer`, `security-reviewer`, `reliability-reviewer`, `backlog-groomer`, `docs-reviewer`, `adversarial-critic` — evaluate artifacts, return markdown reports | Read-only; never writes to filesystem or mutates GitHub |
 | **Author-gateway** (subagent) | `domain-researcher`, `solutions-architect` — invoke write-capable skills for docs artifacts only | Limited write via skill (docs only, not production code) |
 | **Skill** | Slash-command (`/plan`, `/adr`, `/implement`, `/review`, `/feature`, etc.) executing under main-loop authority | Main-loop authority |
 | **GitHub MCP** | MCP server invocable from inside the pipeline; ACL layer over GitHub platform | Pipeline-scoped GitHub API calls |
@@ -163,7 +163,7 @@ Invariants:
 - State machine: `{pending → agreed | pending → deferred | pending → disagreed | disagreed → reconciled | disagreed → deferred}` — `disagreed` entered via `RecordTwoVoiceResult(disagreed)`; `deferred` reachable from `pending` (Codex skip) and from `disagreed` (unresolved conflict)
 - Terminal states (`agreed`, `reconciled`, `deferred`) are monotonically stable: no backward transition out of any terminal state.
 - `TwoVoiceReview.state ∈ {agreed, reconciled, deferred}` is required for `FeatureRun.dod_state` to reach `done`.
-- `ReviewArtifact` entities of type `claude_review` and `codex_review` are owned by this aggregate. `advisor_critique` type stays in `FeatureRun` — advisor is not part of two-voice review (per `vocabulary.md`, ADR-0020).
+- `ReviewArtifact` entities of type `claude_review` and `codex_review` are owned by this aggregate. `advisor_critique` type stays in `FeatureRun` — advisor is not part of two-voice review (per `vocabulary.md`, ADR-0020). `adversarial-critic` findings are context that enriches `claude_review`; they do NOT constitute a fourth `ReviewArtifact` type. The type set is stable at three: `claude_review`, `codex_review`, `advisor_critique`.
 - `RequestSecurityReview` and `RequestReliabilityReview` commands must **not** be migrated into `TwoVoiceReview` — they are conditional prod-bound gates owned by `FeatureRun` (ADR-0020 Confirmation §5).
 
 ---
@@ -178,6 +178,7 @@ BC-wide flat table (not per-aggregate). Policy trigger ownership follows the own
 | `ADRDrafted` | FeatureRun | Invoke `adr-reviewer` |
 | PR contains prod-bound change | FeatureRun | Invoke `security-reviewer` and `reliability-reviewer` inside `/review` phase |
 | PR touches human-facing docs (`docs/runbooks/`, `docs/architecture/`, `docs/principles.md`, `README.md`) | FeatureRun | Invoke `docs-reviewer` inside `/review` phase |
+| Layer 1 passes on any `/review` invocation | FeatureRun | Invoke `adversarial-critic` (unconditional); findings are context for `claude_review` ReviewArtifact, not a new artifact type |
 | `TwoVoiceDisagreed` and unresolved at PR time | TwoVoiceReview | Create deferred-review issue (`type:deferred-review`) |
 | `CommitAttempted` without issue-ref | GovernanceRun | `GovernanceBlocked` |
 | `CommitAttempted` on ADR-significant change without ADR-link | GovernanceRun | `GovernanceBlocked` |

--- a/docs/domain/vocabulary.md
+++ b/docs/domain/vocabulary.md
@@ -132,6 +132,14 @@ The rule that any task longer than one session must have a GitHub issue before w
 
 ---
 
+## Layer 1 Gate
+
+The deterministic verification phase within `/review` that runs `~/.claude/scripts/verify.sh` before any LLM analysis. Outputs `LAYER1_PASSED` or `LAYER1_FAILED`. When it passes, Layer 2 (LLM review) and Layer 3 (adversarial-critic) both proceed. When it fails, `/review` stops and the operator must resolve the deterministic findings before re-invoking.
+
+*Discriminating note:* "Layer 1 Gate" is often abbreviated "Layer 1" in implementation artifacts (`bootstrap/commands/review.md`). In domain language, use "Layer 1 Gate" to distinguish it from the LLM-review phases (Layer 2, Layer 3). The gate is a single `verify.sh` invocation — not a separate aggregate; it is a precondition step owned by `FeatureRun`.
+
+---
+
 ## Main Loop
 
 The Sonnet model instance that orchestrates all pipeline actions within a session. Has write authority over files and GitHub (within permissions). Distinct from the advisor (read-only) and agents (subagents with constrained toolsets).

--- a/docs/domain/vocabulary.md
+++ b/docs/domain/vocabulary.md
@@ -26,7 +26,7 @@ The Opus model instance invoked via `advisor()` to critique plans and review com
 ## Agent
 
 A Claude Code subagent with a defined role and constrained toolset. Two subtypes per ADR 0007:
-- **Read-only critic** — reads and evaluates, returns markdown report, never writes: `adr-reviewer`, `domain-reviewer`, `security-reviewer`, `reliability-reviewer`, `backlog-groomer`, `docs-reviewer`.
+- **Read-only critic** — reads and evaluates, returns markdown report, never writes: `adr-reviewer`, `domain-reviewer`, `security-reviewer`, `reliability-reviewer`, `backlog-groomer`, `docs-reviewer`, `adversarial-critic`.
 - **Author-gateway** — invokes a write-capable skill for docs artifacts only: `domain-researcher`, `solutions-architect`.
 
 *Discriminating note:* "agent" in generic AI parlance means any AI agent. Inside this BC it means specifically a Claude Code subagent with the constraints above. See `docs/decisions/0007-read-only-critic-agents.md`.

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -110,6 +110,7 @@ Continuity не блокирующий приоритет в моменте — 
 - [ ] Domain-доки обновлены, если изменилась граница BC или термин
 - [ ] Unit-тесты написаны; integration-тесты для cross-BC путей; coverage ≥ project floor (дефолт 80%)
 - [ ] `/review` (Claude) одобрил
+- [ ] `adversarial-critic` запущен внутри `/review`; BLOCK-findings устранены ИЛИ задокументированы как осознанный компромисс в PR-треде
 - [ ] `/codex-review` (Codex) одобрил ИЛИ создан `type:deferred-review` issue с обоснованием graceful degradation
 - [ ] Разногласия между Claude и Codex разрешены в PR-треде (консенсус или фиксация disagreement)
 - [ ] Human self-review выполнен

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -110,7 +110,7 @@ Continuity не блокирующий приоритет в моменте — 
 - [ ] Domain-доки обновлены, если изменилась граница BC или термин
 - [ ] Unit-тесты написаны; integration-тесты для cross-BC путей; coverage ≥ project floor (дефолт 80%)
 - [ ] `/review` (Claude) одобрил
-- [ ] `adversarial-critic` запущен внутри `/review`; BLOCK-findings устранены ИЛИ задокументированы как осознанный компромисс в PR-треде
+- [ ] `adversarial-critic` запущен внутри `/review` (сканирует 8 классов LLM-ленивых паттернов, см. `docs/runbooks/feature-pipeline.md §6`); BLOCK-findings устранены ИЛИ задокументированы как осознанный компромисс в PR-треде
 - [ ] `/codex-review` (Codex) одобрил ИЛИ создан `type:deferred-review` issue с обоснованием graceful degradation
 - [ ] Разногласия между Claude и Codex разрешены в PR-треде (консенсус или фиксация disagreement)
 - [ ] Human self-review выполнен

--- a/docs/runbooks/feature-pipeline.md
+++ b/docs/runbooks/feature-pipeline.md
@@ -145,6 +145,13 @@ Claude сам критикует свой diff по severity.
 
 `docs-reviewer` проверяет читаемость для новичка, исполняемость примеров, корректность диаграмм, отсутствие устаревших разделов. Завершается до перехода к `/codex-review`. Если PR затрагивает и prod-bound пути, и human-facing docs — оба агента вызываются в фазе `/review`, порядок между ними произвольный.
 
+**На каждом PR (unconditional) — после того, как Layer 1 прошёл:**
+```
+@agent-adversarial-critic
+```
+
+Передать diff как context в разговор. `adversarial-critic` проверяет 8 классов ленивых паттернов LLM (дублирование, symptom-fix, narrow-case, copy-paste, truncated-file, magic constants, TODO-без-тикета, commented-out code) и загружает `docs/anti-patterns.md` в context. Возвращает список находок с severity BLOCK/SUGGEST/NIT. BLOCK-findings блокируют переход к `/codex-review`; SUGGEST/NIT — оператор решает.
+
 ### 7. Codex review (two-voice)
 
 ```

--- a/docs/runbooks/feature-pipeline.md
+++ b/docs/runbooks/feature-pipeline.md
@@ -145,12 +145,12 @@ Claude сам критикует свой diff по severity.
 
 `docs-reviewer` проверяет читаемость для новичка, исполняемость примеров, корректность диаграмм, отсутствие устаревших разделов. Завершается до перехода к `/codex-review`. Если PR затрагивает и prod-bound пути, и human-facing docs — оба агента вызываются в фазе `/review`, порядок между ними произвольный.
 
-**На каждом PR (unconditional) — после того, как Layer 1 прошёл:**
+**На каждом PR (unconditional) — после того, как детерминированные gate'ы (`verify.sh`) прошли:**
 ```
 @agent-adversarial-critic
 ```
 
-Передать diff как context в разговор. `adversarial-critic` проверяет 8 классов ленивых паттернов LLM (дублирование, symptom-fix, narrow-case, copy-paste, truncated-file, magic constants, TODO-без-тикета, commented-out code) и загружает `docs/anti-patterns.md` в context. Возвращает список находок с severity BLOCK/SUGGEST/NIT. BLOCK-findings блокируют переход к `/codex-review`; SUGGEST/NIT — оператор решает.
+Передай diff в разговор (`git diff HEAD~1..HEAD` или staged diff). `adversarial-critic` проверяет 8 классов ленивых паттернов LLM (дублирование, `symptom-fix-not-root`, `narrow-special-case`, `copy-paste-adjacent-hunk`, `truncated-file`, `magic-constant`, `todo-without-ticket`, `commented-out-code`) и загружает `docs/anti-patterns.md` в context. Возвращает список находок с severity BLOCK/SUGGEST/NIT. BLOCK-findings блокируют переход к `/codex-review` или документируются как осознанный компромисс в PR-треде; SUGGEST/NIT — оператор решает.
 
 ### 7. Codex review (two-voice)
 


### PR DESCRIPTION
## What & Why

Closes #123
Implements docs/decisions/0007-read-only-critic-agents.md

Adds `adversarial-critic` — a new read-only critic agent (9th agent) that runs unconditionally inside every `/review` after deterministic gates pass. It scans PRs for 8 classes of LLM lazy patterns that existing critics miss because they guard their named concern only.

## Changes

- `bootstrap/agents/adversarial-critic.md` — new agent (`tools: Read, Glob, Grep`, sonnet, yellow); 8 pattern classes; loads `docs/anti-patterns.md` at runtime; structured findings output
- `bootstrap/commands/review.md` — Layer 3 section: unconditional adversarial-critic after Layer 1; sanity check, failure handling, audit-trail guidance
- `bootstrap/commands/feature.md` — step 7c added (always-on, graceful-degradation path documented)
- `CLAUDE.md` — agent added to Agents table + Conditional gates table
- `README.md` — Agents (8) → (9) with parenthetical context
- `docs/architecture/overview.md` — ASCII diagram updated
- `docs/domain/overview.md` — Actors table, Policies table, TwoVoiceReview invariant note; + Layer 1 Gate Policies trigger (canonical UL term)
- `docs/domain/vocabulary.md` — Read-only Critic entry updated; + Layer 1 Gate UL definition
- `docs/principles.md` — DoD criterion added with description + runbook link
- `.github/pull_request_template.md` — DoD checkbox added
- `docs/runbooks/feature-pipeline.md` — §6 Review: adversarial-critic step with concrete invocation, diff-passing example, gate semantics
- `docs/anti-patterns.md` — stale forward-reference updated

## Definition of Done

- [ ] ADR merged (если архитектурно значимо) — N/A: follows ADR-0007 pattern; no new triggers fire
- [ ] Domain docs обновлены (если граница BC изменилась) — ✓ overview.md + vocabulary.md updated; **domain-reviewer APPROVE** (commit 81a4618)
- [ ] Тесты: unit / integration; coverage ≥ floor — lint-prompts PASS on all 3 prompt artifacts; integration test: see escape hatch below
- [ ] `/review` прошёл — ✓ APPROVE
- [ ] `adversarial-critic` запущен внутри `/review` — ✓ APPROVE (all 8 classes clean)
- [ ] `/codex-review` прошёл — ✓ 2 BLOCKs caught and fixed
- [ ] Разногласия между ревьюерами разрешены — ✓ two-voice agreed after fixes
- [ ] Security scans clean — ✓ security-reviewer APPROVE
- [ ] Docs обновлены — ✓
- [ ] Human-facing docs reviewed — ✓ docs-reviewer APPROVE after 2 CRITICAL fixes
- [ ] Reliability reviewed — ✓ reliability-reviewer APPROVE, 4 SUGGESTs addressed
- [ ] CI зелёный — pending
- [ ] Conventional Commit + issue-ref — ✓ governance hook passed

## QA

**Tests:** `scripts/lint-prompts.sh` PASS (exit 0) on all 3 prompt artifacts. No logic files modified.

Integration test escape hatch: the acceptance criteria call for invoking `@agent-adversarial-critic` against a crafted diff with planted `truncated-file`, `symptom-fix-not-root`, and `narrow-special-case` patterns to assert all three appear with correct slugs. No automated harness exists for prompt-artifact agents. Deferral reason: agent behavior is prompt-defined; the `scripts/lint-prompts.sh` PASS verifies structural correctness (all required sections present, valid frontmatter). Functional smoke-test is a manual step; see #171 for follow-up tracking.

**Docs:** `docs/runbooks/feature-pipeline.md` §6 patched in /qa as stale-doc fix (Claude-authored). All other contracts current.

## Reviewer notes

- Plan drift (noted): `docs/runbooks/feature-pipeline.md` patched in /qa; not in plan §2 — correct and necessary
- ADR-0007 stale count follow-up: issue #171 opened ("5 pure critics" stale since reliability/docs-reviewer added; now 7)
- Domain-reviewer BLOCK fixed (commit 81a4618): "Layer 1 Gate" added to vocabulary.md as canonical UL term; Policies trigger updated to match
- Domain model: adversarial-critic findings = context for `claude_review`, NOT a 4th ReviewArtifact type; type set stable at three