### PR TITLE
docs(adr): promote ADR-0022 status proposed → accepted #118

### DIFF
--- a/docs/decisions/0022-pbt-integration-via-installer-template.md
+++ b/docs/decisions/0022-pbt-integration-via-installer-template.md
@@ -1,6 +1,6 @@
 # 0022. Deliver Hypothesis property-based testing into Python pet-projects via `--target` installer template
 
-* Status: proposed
+* Status: accepted
 * Date: 2026-04-29
 * Deciders: Lenivvenil (operator decides; draft by solutions-architect)
 * Tags: pipeline, testing, installation, qa, hypothesis


### PR DESCRIPTION
## Summary

- Promotes `docs/decisions/0022-pbt-integration-via-installer-template.md` status from `proposed` to `accepted`
- Implementation for issue #118 merged 2026-04-30 in PRs #163 + #164; the ADR lifecycle state was never updated at that time

Closes #118

## QA

Carve-out: ADR-only diff. No test or docs check required.

## Review notes

- `/review` (Claude): zero BLOCK, one SUGGEST (open a sweep issue for the other 6 ADRs in the same state — not merge-blocking)
- `adversarial-critic`: no lazy-pattern findings
- `/codex-review` (Codex): zero BLOCK; two NITs dismissed with evidence (Consequences section already exists; date convention is draft-date, not acceptance-date)
- Two-voice verdict: **agreed**