### PR TITLE
ci(board): auto-add new issues to project board on open #176

### DIFF
--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -3,21 +3,38 @@ name: Project board sync
 # Requires secret ADD_TO_PROJECT_TOKEN — a PAT with `project` scope.
 # Create at: github.com/settings/tokens → Classic → project ✓
 # Add as: Settings → Secrets → Actions → ADD_TO_PROJECT_TOKEN
+#
+# Note: permissions: block governs GITHUB_TOKEN only (unused here).
+# Board write access comes from the PAT in ADD_TO_PROJECT_TOKEN.
 
 on:
   issues:
-    types: [opened]
+    types: [opened, transferred]
 
 jobs:
   add-to-board:
     runs-on: ubuntu-latest
-    permissions:
-      issues: read
+    timeout-minutes: 5
+    if: ${{ secrets.ADD_TO_PROJECT_TOKEN != '' }}
+    permissions: {}
+    env:
+      GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_TOKEN }}
+      ISSUE_URL: ${{ github.event.issue.html_url }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      PROJECT_NUMBER: 5
+      PROJECT_OWNER: Lenivvenil
     steps:
-      - name: Add issue to claude-mini project board
+      - name: Add issue to project board
+        run: |
+          gh project item-add "$PROJECT_NUMBER" \
+            --owner "$PROJECT_OWNER" \
+            --url "$ISSUE_URL"
+
+      - name: Notify on failure
+        if: failure()
+        run: |
+          gh issue comment "$ISSUE_NUMBER" \
+            --body "⚠️ Auto-add to project board failed. Add manually: \`gh project item-add $PROJECT_NUMBER --owner $PROJECT_OWNER --url $ISSUE_URL\`" \
+            --repo "${{ github.repository }}"
         env:
           GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_TOKEN }}
-        run: |
-          gh project item-add 5 \
-            --owner Lenivvenil \
-            --url "${{ github.event.issue.html_url }}"

--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -1,0 +1,23 @@
+name: Project board sync
+
+# Requires secret ADD_TO_PROJECT_TOKEN — a PAT with `project` scope.
+# Create at: github.com/settings/tokens → Classic → project ✓
+# Add as: Settings → Secrets → Actions → ADD_TO_PROJECT_TOKEN
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-to-board:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+    steps:
+      - name: Add issue to claude-mini project board
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_TOKEN }}
+        run: |
+          gh project item-add 5 \
+            --owner Lenivvenil \
+            --url "${{ github.event.issue.html_url }}"

--- a/docs/runbooks/incident-recovery.md
+++ b/docs/runbooks/incident-recovery.md
@@ -248,3 +248,35 @@ git checkout <commit-before-incident>
    ```
 2. Открой issue в claude-mini с `type:bug`
 3. Если специфично для Claude Code — https://github.com/anthropics/claude-code/issues
+
+---
+
+## Project board sync — issue не попал на доску
+
+### Симптомы
+- Новый issue открыт, но отсутствует на project board
+- Workflow `project-board-sync` показывает красный статус в Actions
+
+### Причины и действия
+
+**1. Секрет `ADD_TO_PROJECT_TOKEN` не настроен**
+- Workflow имеет `if: secrets.ADD_TO_PROJECT_TOKEN != ''` — молча пропустит
+- Добавить PAT: repo Settings → Secrets → Actions → `ADD_TO_PROJECT_TOKEN` (scope: `project`)
+
+**2. PAT истёк или не имеет `project` scope**
+- Проверить: `GH_TOKEN=<pat> gh project item-list 5 --owner Lenivvenil --limit 1`
+- Пересоздать PAT: github.com/settings/tokens → Classic → project ✓
+
+**3. Добавить пропущенный issue вручную**
+```bash
+gh project item-add 5 --owner Lenivvenil --url https://github.com/Lenivvenil/claude-mini/issues/<N>
+```
+
+**4. Backfill всех пропущенных issues**
+```bash
+gh issue list --state open --json number,url --limit 100 | \
+  jq -r '.[].url' | \
+  while read url; do
+    gh project item-add 5 --owner Lenivvenil --url "$url" 2>/dev/null && echo "✓ $url" || echo "⚠ $url"
+  done
+```


### PR DESCRIPTION
## Summary

Workflow срабатывает на `issues: opened` + `transferred` и добавляет issue в project board #5.

## Review BLOCKs resolved

- **Script injection** — `html_url` теперь через `env:`, не напрямую в `run:`
- **Magic constants** — `PROJECT_NUMBER` и `PROJECT_OWNER` в `env:` на уровне job
- **Missing event** — добавлен `transferred` тип
- **Secret guard** — `if: ${{ secrets.ADD_TO_PROJECT_TOKEN != '' }}` пропускает job без секрета
- **Observable failure** — при сбое комментарий на issue с инструкцией добавить вручную
- **Recovery runbook** — секция в `docs/runbooks/incident-recovery.md`
- **Wrong issue ref** — предыдущий коммит ссылался на #176 (pruning PoC); исправлено на #178

## Setup required

PAT с `project` scope → repo Settings → Secrets → `ADD_TO_PROJECT_TOKEN`

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)