### PR TITLE
fix(board-sync): secrets context in job-if → env check in steps #178

### DIFF
--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -1,11 +1,12 @@
 name: Project board sync
 
-# Requires secret ADD_TO_PROJECT_TOKEN — a PAT with `project` scope.
+# Requires secret ADD_TO_PROJECT_TOKEN — a PAT (classic, `project` scope).
+# Minimum required scope: project (read+write on all user projects).
 # Create at: github.com/settings/tokens → Classic → project ✓
 # Add as: Settings → Secrets → Actions → ADD_TO_PROJECT_TOKEN
 #
-# Note: permissions: block governs GITHUB_TOKEN only (unused here).
-# Board write access comes from the PAT in ADD_TO_PROJECT_TOKEN.
+# Note: permissions: {} drops all GITHUB_TOKEN grants — unused here.
+# Board write access comes entirely from ADD_TO_PROJECT_TOKEN.
 
 on:
   issues:
@@ -15,7 +16,6 @@ jobs:
   add-to-board:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: ${{ secrets.ADD_TO_PROJECT_TOKEN != '' }}
     permissions: {}
     env:
       GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_TOKEN }}
@@ -24,17 +24,22 @@ jobs:
       PROJECT_NUMBER: 5
       PROJECT_OWNER: Lenivvenil
     steps:
+      - name: Check token
+        if: env.GH_TOKEN == ''
+        run: |
+          echo "::warning::ADD_TO_PROJECT_TOKEN not set — skipping board add. See docs/runbooks/incident-recovery.md"
+          exit 0
+
       - name: Add issue to project board
+        if: env.GH_TOKEN != ''
         run: |
           gh project item-add "$PROJECT_NUMBER" \
             --owner "$PROJECT_OWNER" \
             --url "$ISSUE_URL"
 
       - name: Notify on failure
-        if: failure()
+        if: failure() && env.GH_TOKEN != ''
         run: |
           gh issue comment "$ISSUE_NUMBER" \
             --body "⚠️ Auto-add to project board failed. Add manually: \`gh project item-add $PROJECT_NUMBER --owner $PROJECT_OWNER --url $ISSUE_URL\`" \
             --repo "${{ github.repository }}"
-        env:
-          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_TOKEN }}


### PR DESCRIPTION
## Summary

Codex review caught a real issue: `if: ${{ secrets.ADD_TO_PROJECT_TOKEN != '' }}` на уровне job is discouraged by GitHub's security guide and can fail in some runner contexts with "Unrecognized named-value: 'secrets'".

**Fix:** removed job-level `if:` on `secrets.*`, replaced with `if: env.GH_TOKEN == ''` / `if: env.GH_TOKEN != ''` guards on individual steps. Also removed redundant `GH_TOKEN` env declaration in the failure step (already inherited from job-level env).

## Two-voice

Codex caught this, Claude missed it. Agreement that step-level env check is the right pattern.

Closes #178 (partially — PAT setup still manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)