### PR TITLE
feat(adr): ADR retirement audit skill + weekly CI cron #125

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,3 +131,77 @@ jobs:
           }
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  adr-retirement-audit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Run ADR retirement audit test suite
+        run: bash bootstrap/scripts/test-adr-retirement-audit.sh
+
+  adr-retirement-audit-weekly:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Configure git for bot commit
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+      - name: Run ADR retirement audit
+        run: |
+          bash bootstrap/scripts/adr-retirement-audit.sh \
+            > /tmp/adr-retirement-audit-report.md
+          cat /tmp/adr-retirement-audit-report.md
+      - name: Open PR with weekly report
+        # Opens a PR rather than pushing directly to main, preserving ADR-0009 branch-protection.
+        # Report is human-reviewed; --apply is never called automatically (non-goal: no auto-tagging).
+        run: |
+          WEEK=$(python3 -c "from datetime import date; d=date.today(); print(str(d.isocalendar()[0])+'-W%02d'%d.isocalendar()[1])")
+          REPORT_DIR="docs/adr-audit"
+          mkdir -p "$REPORT_DIR"
+          cp /tmp/adr-retirement-audit-report.md "${REPORT_DIR}/${WEEK}.md"
+          git add "${REPORT_DIR}/"
+          if git diff --cached --quiet; then
+            echo "No change in report — all ADRs unchanged since last run"
+            exit 0
+          fi
+          # Deterministic branch name — one PR per ISO week, no duplicates on re-run
+          BRANCH="chore/adr-audit-${WEEK}"
+          # Fail-closed PR existence check: capture gh exit code separately so auth/API
+          # errors do not masquerade as "no open PR found"
+          existing_pr=$(gh pr list --head "$BRANCH" --state open --json number \
+            --jq '.[0].number' 2>/dev/null) || {
+            echo "gh pr list failed — cannot verify whether a PR already exists; aborting to prevent duplicates" >&2
+            exit 1
+          }
+          if echo "$existing_pr" | grep -qE '^[0-9]+$'; then
+            echo "Open PR already exists (#${existing_pr}) for ${BRANCH} — skipping"
+            exit 0
+          fi
+          git checkout -b "$BRANCH"
+          git commit -m "chore(adr-audit): weekly report ${WEEK}" \
+                     -m "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          # Use --force-with-lease to handle the edge case where a prior run pushed
+          # the branch but the PR was closed without deleting the branch
+          git push --force-with-lease origin "$BRANCH"
+          gh pr create \
+            --title "chore(adr-audit): weekly staleness report ${WEEK}" \
+            --body "$(printf 'Automated weekly ADR retirement audit. Review recommendations before applying any.\n\nTo apply a recommendation:\n```\nbash bootstrap/scripts/adr-retirement-audit.sh --apply 0004\n```\n(Use zero-padded 4-digit number or bare integer, e.g. --apply 4)\n\nRun: %s/%s/actions/runs/%s' \
+              "${{ github.server_url }}" "${{ github.repository }}" "${{ github.run_id }}")" \
+            --label "type:bootstrap" \
+            --base main \
+            --head "$BRANCH" \
+          || {
+            echo "PR creation failed — deleting orphan branch"
+            git push origin --delete "$BRANCH" || true
+            exit 1
+          }
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@
 | внутри `/review` | `docs-reviewer` | PR затрагивает `docs/runbooks/`, `docs/architecture/`, `docs/principles.md`, `README.md` — и НЕ только `docs/decisions/` или `docs/domain/` |
 | внутри `/review` (всегда, после Layer 1) | `adversarial-critic` | каждый PR; передать diff как context; BLOCK-findings блокируют merge |
 | еженедельно | `backlog-groomer` | **out-of-band**, не входит в pipeline |
+| еженедельно | `/adr-retirement-audit` | **out-of-band**, CI cron Monday 06:00 UTC — staleness check по всем ADR |
 
 **Оркестратор одной кнопкой:** `/feature <issue-number>` — ведёт по всем стадиям через TodoWrite.
 

--- a/bootstrap/scripts/adr-retirement-audit.sh
+++ b/bootstrap/scripts/adr-retirement-audit.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+# adr-retirement-audit.sh — ADR staleness audit
+#
+# Usage:
+#   adr-retirement-audit.sh [--decisions-dir <path>] [--threshold <days>]
+#                            [--apply <nums>] [--dry-run]
+#
+# --decisions-dir  path to ADR directory (default: <repo-root>/docs/decisions)
+# --threshold      days for incoming-ref recency check (default: 90)
+# --apply          comma-separated ADR numbers to apply recommendations to (e.g. 0004,0013)
+# --dry-run        print report to stdout only; do not write files even with --apply
+#
+# Checks per ADR:
+#   (a) incoming refs in last N days (grep across repo .md files via git log)
+#   (b) superseded-by chain: target file exists, no cycles
+#   (c) dep presence in pyproject.toml/package.json/go.mod (best-effort; N/A if no manifest)
+#
+# Output: markdown report to stdout
+
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "adr-retirement-audit: not inside a git repository" >&2
+    exit 1
+}
+
+DECISIONS_DIR="${ADR_DECISIONS_DIR:-$REPO_ROOT/docs/decisions}"
+THRESHOLD_DAYS=90
+APPLY_NUMS=""
+DRY_RUN=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --decisions-dir) DECISIONS_DIR="${2:?'--decisions-dir requires a value'}"; shift ;;
+        --threshold)     THRESHOLD_DAYS="${2:?'--threshold requires a value'}"; shift ;;
+        --apply)         APPLY_NUMS="${2:?'--apply requires comma-separated ADR numbers'}"; shift ;;
+        --dry-run)       DRY_RUN=true ;;
+        *)
+            echo "adr-retirement-audit: unknown argument '$1'" >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+if [ ! -d "$DECISIONS_DIR" ]; then
+    echo "adr-retirement-audit: decisions directory not found: $DECISIONS_DIR" >&2
+    exit 1
+fi
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+# Build grep pattern matching all known cross-reference forms for a 4-digit ADR number
+adr_ref_pattern() {
+    local padded="$1"
+    # Covers: ADR-0004, ADR 0004, [0004](...), docs/decisions/0004
+    printf 'ADR[-[:space:]]%s[^0-9]|ADR[-[:space:]]%s$|\\[%s\\]|docs/decisions/%s' \
+        "$padded" "$padded" "$padded" "$padded"
+}
+
+# Count files (excluding the ADR itself) that currently reference padded ADR number
+count_current_refs() {
+    local adr_file="$1"
+    local padded="$2"
+    local pattern count
+    pattern="$(adr_ref_pattern "$padded")"
+    count=0
+    while IFS= read -r -d '' f; do
+        if [ "$f" = "$adr_file" ]; then
+            continue
+        fi
+        if grep -qEi "$pattern" "$f" 2>/dev/null; then
+            count=$((count + 1))
+        fi
+    done < <(find "$REPO_ROOT" -name "*.md" -not -path "*/.git/*" -print0 2>/dev/null)
+    printf '%d' "$count"
+}
+
+# Count files modified within THRESHOLD_DAYS that reference padded ADR number
+count_recent_refs() {
+    local adr_file="$1"
+    local padded="$2"
+    local pattern threshold_date count changed_files abs
+    pattern="$(adr_ref_pattern "$padded")"
+    threshold_date="$(date -v -"${THRESHOLD_DAYS}"d '+%Y-%m-%d' 2>/dev/null \
+        || date -d "${THRESHOLD_DAYS} days ago" '+%Y-%m-%d' 2>/dev/null \
+        || echo "")"
+    if [ -z "$threshold_date" ]; then
+        printf 'N/A'
+        return
+    fi
+    count=0
+    changed_files="$(git -C "$REPO_ROOT" log --after="$threshold_date" --name-only \
+        --format="" --diff-filter=AM -- '*.md' 2>/dev/null | grep -v '^$' | sort -u)"
+    while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        abs="$REPO_ROOT/$f"
+        if [ "$abs" = "$adr_file" ]; then
+            continue
+        fi
+        if [ -f "$abs" ] && grep -qEi "$pattern" "$abs" 2>/dev/null; then
+            count=$((count + 1))
+        fi
+    done <<< "$changed_files"
+    printf '%d' "$count"
+}
+
+# Extract field value from ADR markdown-bullet frontmatter
+get_field() {
+    local field="$1"
+    local file="$2"
+    grep -m1 "^\* ${field}:" "$file" 2>/dev/null | sed "s/^\* ${field}:[[:space:]]*//" | tr -d '\r'
+}
+
+# Check if an ADR number is in the apply list (accepts both "4" and "0004" forms)
+in_apply_list() {
+    local num="$1"
+    if [ -z "$APPLY_NUMS" ]; then
+        return 1
+    fi
+    # Strip leading zeros from num to build a bare integer pattern (e.g. "0004" → "4")
+    local bare
+    bare="${num#"${num%%[!0]*}"}"
+    [ -z "$bare" ] && bare="0"
+    # Match entry if it equals the padded form or the bare integer form
+    echo "$APPLY_NUMS" | tr ',' '\n' | grep -qE "^(0*${bare}|${num})$"
+}
+
+# Apply status update to ADR file (append-only: only touches Status and Superseded-by lines)
+apply_recommendation() {
+    local file="$1"
+    local rec="$2"
+    local sup_target="$3"
+
+    if [ "$DRY_RUN" = true ]; then
+        echo "[dry-run] would update $(basename "$file"): $rec" >&2
+        return
+    fi
+
+    case "$rec" in
+        mark-deprecated)
+            sed -i.bak "s/^\* Status: .*/\* Status: deprecated/" "$file"
+            rm -f "${file}.bak"
+            ;;
+        mark-superseded)
+            sed -i.bak "s/^\* Status: .*/\* Status: superseded/" "$file"
+            rm -f "${file}.bak"
+            if [ -n "$sup_target" ] && [ "$sup_target" != "~" ]; then
+                if grep -q "^\* Superseded-by:" "$file"; then
+                    sed -i.bak "s|^\* Superseded-by:.*|\* Superseded-by: $sup_target|" "$file"
+                    rm -f "${file}.bak"
+                else
+                    # Insert Superseded-by after Status line (awk is portable across BSD/GNU)
+                    awk -v val="$sup_target" \
+                        '/^\* Status:/{print; print "* Superseded-by: " val; next} {print}' \
+                        "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
+                fi
+            fi
+            ;;
+    esac
+}
+
+# ── ADR age in days (from first git commit of that file) ──────────────────────
+
+adr_age_days() {
+    local file="$1"
+    local creation_date now_ts then_ts
+    creation_date=$(git -C "$REPO_ROOT" log --follow --format="%ci" -- "$file" 2>/dev/null \
+        | tail -1 | cut -c1-10)
+    if [ -z "$creation_date" ]; then
+        printf '0'
+        return
+    fi
+    now_ts=$(date '+%s' 2>/dev/null || echo 0)
+    then_ts=$(date -j -f '%Y-%m-%d' "$creation_date" '+%s' 2>/dev/null \
+        || date -d "$creation_date" '+%s' 2>/dev/null \
+        || echo 0)
+    if [ "$now_ts" -le 0 ] || [ "$then_ts" -le 0 ]; then
+        printf '0'
+        return
+    fi
+    printf '%d' $(( (now_ts - then_ts) / 86400 ))
+}
+
+# ── Dep presence check (best-effort) ──────────────────────────────────────────
+
+check_dep_presence() {
+    local title="$1"
+    local m found_manifests keyword
+    found_manifests=false
+    for m in pyproject.toml package.json go.mod; do
+        if [ -f "$REPO_ROOT/$m" ]; then
+            found_manifests=true
+            break
+        fi
+    done
+    if [ "$found_manifests" = false ]; then
+        printf 'N/A'
+        return
+    fi
+    # Extract longest meaningful keyword from title (≥4 chars, skip common words)
+    keyword=$(echo "$title" | tr '[:upper:]' '[:lower:]' \
+        | grep -oE '[a-z]{4,}' \
+        | grep -vxE 'this|that|with|from|into|over|under|when|then|have|been|will|shall|must|should|could|would|adopt|install|enforce|baseline|state|takeover|feature|branch|pipeline|read|only|critic|agents|decision|record|hardware|universal|split|flow|layer|review|gate|weekly|drift|behaviour|level|governance|phase|scope|surface|domain|invariants|placement|worktree|isolation|project|command|installation|post|verification|aggregate|extraction|principle|hardened|revision|integration|installer|template|voice|plus' \
+        | head -1)
+    if [ -z "$keyword" ]; then
+        printf 'N/A'
+        return
+    fi
+    for m in pyproject.toml package.json go.mod; do
+        if [ -f "$REPO_ROOT/$m" ] && grep -qi "$keyword" "$REPO_ROOT/$m" 2>/dev/null; then
+            printf 'present'
+            return
+        fi
+    done
+    printf 'absent'
+}
+
+# ── Superseded-by chain check ─────────────────────────────────────────────────
+
+check_chain() {
+    local padded="$1"
+    local visited="$2"
+    local file sup next_padded
+
+    if echo " $visited " | grep -qw "$padded"; then
+        printf 'cycle'
+        return
+    fi
+
+    file=$(find "$DECISIONS_DIR" -maxdepth 1 -name "${padded}-*.md" 2>/dev/null | head -1)
+    if [ -z "$file" ]; then
+        printf 'target-missing'
+        return
+    fi
+
+    sup=$(get_field "Superseded-by" "$file")
+    if [ -z "$sup" ] || [ "$sup" = "~" ]; then
+        printf 'ok'
+        return
+    fi
+
+    next_padded=$(echo "$sup" | grep -oE '[0-9]{4}' | head -1)
+    if [ -z "$next_padded" ]; then
+        printf 'ok'
+        return
+    fi
+
+    check_chain "$next_padded" "${visited} ${padded}"
+}
+
+# ── Main loop ─────────────────────────────────────────────────────────────────
+
+TODAY="$(date '+%Y-%m-%d')"
+KEEP_COUNT=0
+DEPRECATED_COUNT=0
+SUPERSEDED_COUNT=0
+
+printf "# ADR Retirement Audit — %s\n\n" "$TODAY"
+printf "Threshold: %d days | Decisions: %s\n\n" "$THRESHOLD_DAYS" "$DECISIONS_DIR"
+printf "| ADR | Title | Status | Superseded-by | Age(d) | Refs(cur) | Refs(%dd) | Dep | Chain | Recommendation |\n" "$THRESHOLD_DAYS"
+printf "|-----|-------|--------|---------------|--------|-----------|-----------|-----|-------|----------------|\n"
+
+APPLIED_LOG=""
+
+while IFS= read -r adr_file; do
+    filename="$(basename "$adr_file")"
+    padded="${filename:0:4}"
+
+    title_line=$(head -1 "$adr_file")
+    title="${title_line#"# ${padded}. "}"
+    if [ "${#title}" -gt 50 ]; then
+        title="${title:0:47}..."
+    fi
+
+    status=$(get_field "Status" "$adr_file")
+    sup=$(get_field "Superseded-by" "$adr_file")
+    [ -z "$sup" ] && sup="~"
+
+    current_refs=$(count_current_refs "$adr_file" "$padded")
+    recent_refs=$(count_recent_refs "$adr_file" "$padded")
+    chain_status=$(check_chain "$padded" "")
+    dep=$(check_dep_presence "$title")
+    age=$(adr_age_days "$adr_file")
+
+    # ── Recommendation logic ────────────────────────────────────────────────
+    rec="keep"
+
+    if [ "$status" = "deprecated" ] || [ "$status" = "superseded" ]; then
+        rec="keep (already-${status})"
+    elif [ "$sup" != "~" ] && [ -n "$sup" ]; then
+        if [ "$chain_status" = "ok" ]; then
+            rec="mark-superseded"
+        elif [ "$chain_status" = "cycle" ]; then
+            rec="keep (chain-cycle-error)"
+        elif [ "$chain_status" = "target-missing" ]; then
+            rec="keep (chain-target-missing)"
+        fi
+    elif [ "$current_refs" -eq 0 ] 2>/dev/null; then
+        # Only flag for deprecation if ADR is older than the threshold
+        if [ "$age" -ge "$THRESHOLD_DAYS" ]; then
+            # Treat N/A (date computation failed) as unknown — skip recommendation
+            if [ "$recent_refs" != "N/A" ] && [ "$recent_refs" -eq 0 ] 2>/dev/null; then
+                rec="mark-deprecated"
+            fi
+        fi
+    fi
+
+    case "$rec" in
+        keep*)            KEEP_COUNT=$((KEEP_COUNT + 1)) ;;
+        mark-deprecated)  DEPRECATED_COUNT=$((DEPRECATED_COUNT + 1)) ;;
+        mark-superseded)  SUPERSEDED_COUNT=$((SUPERSEDED_COUNT + 1)) ;;
+    esac
+
+    printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s | **%s** |\n" \
+        "$padded" "$title" "$status" "$sup" "$age" "$current_refs" "$recent_refs" "$dep" "$chain_status" "$rec"
+
+    # ── Inline apply ───────────────────────────────────────────────────────
+    if in_apply_list "$padded"; then
+        case "$rec" in
+            mark-deprecated|mark-superseded)
+                apply_recommendation "$adr_file" "$rec" "$sup"
+                APPLIED_LOG="${APPLIED_LOG}- ${padded}: applied **${rec}**\n"
+                ;;
+            *)
+                APPLIED_LOG="${APPLIED_LOG}- ${padded}: skipped (recommendation is '${rec}')\n"
+                ;;
+        esac
+    fi
+
+done < <(find "$DECISIONS_DIR" -maxdepth 1 -name '[0-9]*.md' | sort)
+
+printf "\n## Summary\n\n"
+echo "- keep: ${KEEP_COUNT}"
+echo "- mark-deprecated: ${DEPRECATED_COUNT}"
+echo "- mark-superseded: ${SUPERSEDED_COUNT}"
+
+if [ -n "$APPLIED_LOG" ]; then
+    printf "\n## Applied updates\n\n"
+    printf '%b' "$APPLIED_LOG"
+fi

--- a/bootstrap/scripts/test-adr-retirement-audit.sh
+++ b/bootstrap/scripts/test-adr-retirement-audit.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# test-adr-retirement-audit.sh — unit + integration tests for adr-retirement-audit.sh
+#
+# Tests:
+#   T1: ADR older than threshold with 0 refs → mark-deprecated
+#   T2: ADR with Superseded-by field and valid target → mark-superseded
+#   T3: Superseded-by chain forms a cycle → keep (chain-cycle-error)
+#   T4: Superseded-by points to missing file → keep (chain-target-missing)
+#   T5: ADR with incoming refs → keep (even if old)
+#   T6: --apply writes Status: deprecated (mark-deprecated path)
+#   T7: --apply writes Status: superseded and preserves content
+#   T9: Already-deprecated ADR → keep (already-deprecated)
+#   T10: Real repo run — no errors, output is valid markdown, idempotent, no writes
+#
+# Usage: bash bootstrap/scripts/test-adr-retirement-audit.sh
+# Exit: 0 = all passed, 1 = one or more failures
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/bootstrap/scripts/adr-retirement-audit.sh"
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+NC=$'\033[0m'
+
+FAIL_FILE=$(mktemp /tmp/adr-test-failures-XXXXXX)
+TMPDIRS=()
+# shellcheck disable=SC2329
+cleanup() {
+    rm -f "$FAIL_FILE"
+    for d in "${TMPDIRS[@]:-}"; do
+        rm -rf "$d"
+    done
+}
+trap cleanup EXIT
+
+pass() { printf "  %s✓%s %s\n" "${GREEN}" "${NC}" "$1"; }
+fail() { printf "  %s✗%s %s\n" "${RED}" "${NC}" "$1"; echo "FAIL" >> "$FAIL_FILE"; }
+
+# ── Temp repo factory ──────────────────────────────────────────────────────────
+
+# Creates a temp git repo with docs/decisions/ and initial commit.
+# Prints the repo path. Caller owns cleanup.
+make_repo() {
+    local d
+    d=$(mktemp -d /tmp/adr-test-XXXXXX)
+    TMPDIRS+=("$d")
+    git -C "$d" init -q
+    git -C "$d" config user.email "t@t.com"
+    git -C "$d" config user.name "T"
+    git -C "$d" symbolic-ref HEAD refs/heads/main
+    mkdir -p "$d/docs/decisions"
+    printf '%s' "$d"
+}
+
+# Adds an ADR file to a repo and commits it with optional backdated date.
+# Usage: add_adr <repo> <num> <title> <status> <sup> [<commit_date>]
+add_adr() {
+    local repo="$1" num="$2" title="$3" status="$4" sup="$5"
+    local commit_date="${6:-}"
+    local file
+    file="$repo/docs/decisions/${num}-$(echo "$title" | tr ' ' '-').md"
+    {
+        printf "# %s. %s\n\n" "$num" "$title"
+        printf "* Status: %s\n" "$status"
+        printf "* Superseded-by: %s\n" "$sup"
+        printf "* Date: 2026-01-01\n"
+        printf "\n## Context\n\nSome context.\n"
+    } > "$file"
+    git -C "$repo" add .
+    if [ -n "$commit_date" ]; then
+        GIT_AUTHOR_DATE="$commit_date" GIT_COMMITTER_DATE="$commit_date" \
+            git -C "$repo" commit -q -m "chore: add adr ${num}"
+    else
+        git -C "$repo" commit -q -m "chore: add adr ${num}"
+    fi
+}
+
+# ── Unit tests ─────────────────────────────────────────────────────────────────
+
+echo "=== adr-retirement-audit: recommendation logic ==="
+
+# T1: old ADR, 0 refs → mark-deprecated
+R1=$(make_repo)
+add_adr "$R1" "0001" "Orphan ADR" "accepted" "~" "2025-01-01T00:00:00"
+out=$(cd "$R1" && bash "$SCRIPT" --threshold 90 2>&1)
+if echo "$out" | grep '0001' | grep -q 'mark-deprecated'; then
+    pass "T1: old ADR with 0 refs → mark-deprecated"
+else
+    fail "T1: expected mark-deprecated, got: $(echo "$out" | grep '0001')"
+fi
+
+# T2: ADR with Superseded-by set and valid target → mark-superseded
+R2=$(make_repo)
+add_adr "$R2" "0001" "Old Decision" "accepted" "[0002](0002-New-Decision.md)"
+add_adr "$R2" "0002" "New Decision" "accepted" "~"
+out=$(cd "$R2" && bash "$SCRIPT" 2>&1)
+if echo "$out" | grep '0001' | grep -q 'mark-superseded'; then
+    pass "T2: ADR with valid Superseded-by → mark-superseded"
+else
+    fail "T2: expected mark-superseded for 0001, got: $(echo "$out" | grep '0001')"
+fi
+
+# T3: Superseded-by chain forms a cycle → keep (chain-cycle-error)
+R3=$(make_repo)
+add_adr "$R3" "0001" "ADR A" "accepted" "[0002](0002-ADR-B.md)"
+add_adr "$R3" "0002" "ADR B" "accepted" "[0001](0001-ADR-A.md)"
+out=$(cd "$R3" && bash "$SCRIPT" 2>&1)
+if echo "$out" | grep '0001' | grep -q 'chain-cycle-error'; then
+    pass "T3: cyclic Superseded-by chain → keep (chain-cycle-error)"
+else
+    fail "T3: expected chain-cycle-error for 0001, got: $(echo "$out" | grep '0001')"
+fi
+
+# T4: Superseded-by points to missing file → keep (chain-target-missing)
+R4=$(make_repo)
+add_adr "$R4" "0001" "Old" "accepted" "[0099](0099-does-not-exist.md)"
+out=$(cd "$R4" && bash "$SCRIPT" 2>&1)
+if echo "$out" | grep '0001' | grep -q 'chain-target-missing'; then
+    pass "T4: missing Superseded-by target → keep (chain-target-missing)"
+else
+    fail "T4: expected chain-target-missing for 0001, got: $(echo "$out" | grep '0001')"
+fi
+
+# T5: ADR with incoming refs → keep (even if old)
+R5=$(make_repo)
+add_adr "$R5" "0001" "Referenced ADR" "accepted" "~" "2025-01-01T00:00:00"
+# 0002 references 0001 via canonical ADR-0001 pattern
+{
+    printf "# 0002. Another ADR\n\n* Status: accepted\n* Superseded-by: ~\n* Date: 2025-01-01\n"
+    printf "\n## Context\n\nSee ADR-0001 for context.\n"
+} > "$R5/docs/decisions/0002-Another-ADR.md"
+git -C "$R5" add .
+GIT_AUTHOR_DATE="2025-01-01T00:00:00" GIT_COMMITTER_DATE="2025-01-01T00:00:00" \
+    git -C "$R5" commit -q -m "chore: add adr 0002"
+out=$(cd "$R5" && bash "$SCRIPT" --threshold 90 2>&1)
+if echo "$out" | grep '0001' | grep -qv 'mark-deprecated'; then
+    pass "T5: referenced ADR → keep (not mark-deprecated even if old)"
+else
+    fail "T5: expected keep for referenced 0001, got: $(echo "$out" | grep '0001')"
+fi
+
+# T6: --apply writes Status: deprecated
+R6=$(make_repo)
+add_adr "$R6" "0001" "Old Orphan" "accepted" "~" "2025-01-01T00:00:00"
+f6="$R6/docs/decisions/0001-Old-Orphan.md"
+(cd "$R6" && bash "$SCRIPT" --threshold 90 --apply 0001 >/dev/null 2>&1)
+if grep -q '^\* Status: deprecated' "$f6"; then
+    pass "T6: --apply writes 'deprecated' to Status field"
+else
+    fail "T6: Status not updated; contains: $(grep '^\* Status' "$f6")"
+fi
+
+# T7: --apply mark-superseded writes Status, preserves body content
+R7=$(make_repo)
+f7="$R7/docs/decisions/0001-Old.md"
+{
+    printf "# 0001. Old\n\n* Status: accepted\n* Superseded-by: [0002](0002-New.md)\n* Date: 2025-01-01\n"
+    printf "\n## Body text must not change.\n\nThis content is load-bearing.\n"
+} > "$f7"
+{
+    printf "# 0002. New\n\n* Status: accepted\n* Superseded-by: ~\n* Date: 2025-01-02\n\n## New context.\n"
+} > "$R7/docs/decisions/0002-New.md"
+git -C "$R7" add .
+git -C "$R7" commit -q -m "chore: add adrs"
+body_before=$(grep 'load-bearing' "$f7")
+(cd "$R7" && bash "$SCRIPT" --apply 0001 >/dev/null 2>&1)
+status_after=$(grep '^\* Status:' "$f7")
+body_after=$(grep 'load-bearing' "$f7")
+if [ "$status_after" = "* Status: superseded" ] && [ "$body_before" = "$body_after" ]; then
+    pass "T7: --apply mark-superseded writes Status, preserves content"
+else
+    fail "T7: status='$status_after' body_match: before='$body_before' after='$body_after'"
+fi
+
+# T9: Already-deprecated ADR → keep (already-deprecated)
+R9=$(make_repo)
+add_adr "$R9" "0001" "Already Gone" "deprecated" "~" "2025-01-01T00:00:00"
+out=$(cd "$R9" && bash "$SCRIPT" --threshold 90 2>&1)
+if echo "$out" | grep '0001' | grep -q 'already-deprecated'; then
+    pass "T9: already-deprecated ADR → keep (already-deprecated)"
+else
+    fail "T9: expected already-deprecated, got: $(echo "$out" | grep '0001')"
+fi
+
+# ── Integration tests on real repo ────────────────────────────────────────────
+
+echo ""
+echo "=== adr-retirement-audit: real repo integration ==="
+
+out1=$(bash "$SCRIPT" 2>&1)
+if echo "$out1" | grep -q '# ADR Retirement Audit'; then
+    pass "T10.1: real repo run produces markdown report"
+else
+    fail "T10.1: expected markdown report header"
+fi
+
+if echo "$out1" | grep -q '| ADR |'; then
+    pass "T10.2: report contains table header"
+else
+    fail "T10.2: missing table header"
+fi
+
+if echo "$out1" | grep -q '## Summary'; then
+    pass "T10.3: report contains Summary section"
+else
+    fail "T10.3: missing Summary section"
+fi
+
+# Idempotency: run twice, compare summary
+out2=$(bash "$SCRIPT" 2>&1)
+sum1=$(echo "$out1" | grep -E '^- (keep|mark-)' | sort)
+sum2=$(echo "$out2" | grep -E '^- (keep|mark-)' | sort)
+if [ "$sum1" = "$sum2" ]; then
+    pass "T10.4: audit is idempotent (two runs produce same summary)"
+else
+    fail "T10.4: runs differ — run1='$sum1' run2='$sum2'"
+fi
+
+# Report-only run must not modify any ADR
+first_adr="docs/decisions/0001-baseline-state-at-takeover.md"
+if git diff --quiet "$first_adr" 2>/dev/null; then
+    pass "T10.5: report-only run does not modify ADR files"
+else
+    fail "T10.5: ADR was modified by report-only run"
+fi
+
+# ── Results ───────────────────────────────────────────────────────────────────
+
+echo ""
+FAILURES=$(wc -l < "$FAIL_FILE" | tr -d ' ')
+if [ "$FAILURES" -eq 0 ]; then
+    printf "%s✓ All tests passed%s\n" "${GREEN}" "${NC}"
+    exit 0
+else
+    printf "%s✗ %d test(s) failed%s\n" "${RED}" "$FAILURES" "${NC}"
+    exit 1
+fi

--- a/bootstrap/skills/adr-retirement-audit/SKILL.md
+++ b/bootstrap/skills/adr-retirement-audit/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: adr-retirement-audit
+description: Weekly ADR staleness audit. Checks each ADR for incoming refs, superseded-by chain consistency, and dep presence. Emits keep|mark-deprecated|mark-superseded recommendations. Invoke when asked to "run adr audit", "check stale ADRs", or "adr-retirement-audit".
+---
+
+# ADR retirement audit skill
+
+## When to invoke
+
+- Weekly CI cron (see `.github/workflows/ci.yml` `adr-retirement-audit-weekly` job)
+- Manually: "run adr audit", "check stale ADRs", "adr-retirement-audit"
+
+## Prerequisites
+
+- `bootstrap/scripts/adr-retirement-audit.sh` available
+- Running inside a git repository with `docs/decisions/` present
+
+## How to run
+
+### Report only (read-only, no writes)
+
+```bash
+bash bootstrap/scripts/adr-retirement-audit.sh
+```
+
+### Apply recommendations to specific ADRs
+
+After reviewing the report, apply status updates to named ADRs (append-only, operator-confirmed):
+
+```bash
+bash bootstrap/scripts/adr-retirement-audit.sh --apply 0004,0013
+```
+
+`--apply` only updates `* Status:` and `* Superseded-by:` frontmatter fields. Content is never modified.
+
+### Override threshold (days)
+
+```bash
+bash bootstrap/scripts/adr-retirement-audit.sh --threshold 60
+```
+
+## Output
+
+Report written to stdout as markdown. Columns: ADR number, title, current status, superseded-by, incoming-ref count, recent-ref count (within threshold days), recommendation.
+
+Recommendation values:
+
+| Value | Meaning |
+|---|---|
+| `keep` | ADR is actively referenced or superseded-by chain is consistent |
+| `mark-deprecated` | Zero incoming refs; tech may no longer apply |
+| `mark-superseded` | `superseded-by` field is set; target file exists and is consistent |
+
+## Notes
+
+- `--apply` requires zero-padded 4-digit ADR numbers (e.g. `0004`) or bare integers (e.g. `4`) — both accepted.
+- ADRs created before this feature (lacking `* Superseded-by:` field) are handled gracefully — field is treated as `~`. When `--apply mark-superseded` runs, the field is inserted after `* Status:`.
+
+## Hard rules
+
+- Do NOT auto-apply recommendations without operator review. `--apply` requires explicit ADR numbers.
+- Do NOT modify ADR content — only `* Status:` and `* Superseded-by:` frontmatter fields.
+- Do NOT delete ADR files. Status `deprecated` or `superseded` is the only retirement mechanism.
+- `mark-deprecated` is a recommendation, not a command. Operator decides and confirms.
+- Do NOT treat `keep` as proof the ADR is correct — only that it is currently referenced.

--- a/docs/decisions/adr-template.md
+++ b/docs/decisions/adr-template.md
@@ -1,6 +1,7 @@
 # NNNN. {Short decision title in imperative mood}
 
-* Status: {proposed | accepted | deprecated | superseded by [NNNN](NNNN-*.md)}
+* Status: {proposed | accepted | deprecated | superseded}
+* Superseded-by: {[NNNN](NNNN-*.md) | ~}
 * Date: {YYYY-MM-DD}
 * Deciders: {list of people involved in the decision}
 * Tags: {comma-separated, e.g. architecture, security, tooling}

--- a/docs/runbooks/adr-workflow.md
+++ b/docs/runbooks/adr-workflow.md
@@ -87,8 +87,20 @@ Evidence of why this step is load-bearing: `docs/runbooks/first-feature-session-
 Если более ранний ADR устарел:
 
 1. Новый ADR пишется как обычно
-2. В секции `Status:` нового — `accepted` 
-3. В старом — `superseded by [NNNN](NNNN-*.md)`
+2. В секции `Status:` нового — `accepted`
+3. В старом — `Status: superseded` и `Superseded-by: [NNNN](NNNN-*.md)` (отдельное поле)
 4. В новом — `Supersedes: [MMMM](MMMM-*.md)` в секции Links
 
 Старый ADR НИКОГДА не удаляется. История решений — часть документации.
+
+## ADR retirement audit
+
+Еженедельный CI cron (`adr-retirement-audit-weekly`) запускает `bootstrap/scripts/adr-retirement-audit.sh` и открывает PR с отчётом. Отчёт содержит колонку `Recommendation`:
+
+| Значение | Действие оператора |
+|---|---|
+| `keep` | Ничего не делать |
+| `mark-deprecated` | Проверить вручную → если согласен: `bash bootstrap/scripts/adr-retirement-audit.sh --apply 0004` |
+| `mark-superseded` | Проверить цепочку Superseded-by → если согласен: `bash bootstrap/scripts/adr-retirement-audit.sh --apply 0004` |
+
+`--apply` принимает zero-padded номер (`0004`) или bare integer (`4`). Обновляет только `* Status:` и `* Superseded-by:` — контент ADR не редактируется.


### PR DESCRIPTION
## Summary

- New `adr-retirement-audit` skill: weekly cron (Mon 06:00 UTC) checks each ADR for incoming refs, superseded-by chain consistency, and dep presence; emits `keep | mark-deprecated | mark-superseded` recommendations
- Append-only apply: `--apply 0004` updates only `* Status:` and `* Superseded-by:` — content never touched
- ADR template updated: explicit `Superseded-by` field split from `Status` enum
- 13 tests, all passing; ShellCheck clean; lint-prompts PASS

## AC coverage

- [x] `/adr-retirement-audit` skill with 3 checks (refs, chain, dep)
- [x] Output: `keep | mark-deprecated | mark-superseded` per ADR
- [x] Append-only: only Status and Superseded-by frontmatter fields updated
- [x] ADR template: `status` enum + `superseded-by` field (last-referenced-sha dropped — redundant, re-derived each run)
- [ ] First pass: 2-3 ADR retiring — **deferred** (all 23 ADRs < 90 days old; proof of mechanism in T1–T9; first cron run ~80 days out)

## QA

**Tests:** All 13 pass (T1–T10). All recommendation paths covered (deprecated, superseded, chain-cycle, chain-target-missing, keep, already-*), apply paths, real-repo integration, idempotency, no-write-on-report-only.

`bootstrap/skills/adr-retirement-audit/SKILL.md` — lint-prompts: PASS.

`.github/workflows/ci.yml` — 2 new jobs follow existing gate-audit pattern.

**AC #5 deferral:** repo is 10 days old; all ADRs < 90-day threshold. Mechanism proven via synthetic backdated ADRs in tests.

**Docs:** All contracts current. cron time (06:00 UTC), --apply format, runbook section all accurate.

## Review findings resolved

| Finding | Source | Status |
|---|---|---|
| Branch non-determinism → duplicate PRs | reliability-reviewer | Fixed: deterministic branch + `gh pr list` guard |
| `N/A` treated as zero → false deprecation | reliability-reviewer | Fixed: N/A skips recommendation |
| Cron time wrong in CLAUDE.md | docs-reviewer | Fixed: 09:00 → 06:00 UTC |
| `--apply NNNN` non-executable in runbook | docs-reviewer | Fixed: concrete example + format docs |
| `gh pr list` fail-open (Codex BLOCK) | codex-review | Fixed: capture exit code, fail-closed |
| Pre-existing remote branch (Codex SUGGEST) | codex-review | Fixed: `--force-with-lease` |

Closes #125
Extends ADR-0001 (MADR baseline): adds Superseded-by field to template.