### PR TITLE
feat(agnostic): AGENTS.md + CLAUDE.md duality migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,175 @@
+# AGENTS.md — claude-mini
+
+> Этот файл читается любым AI-агентом: Claude Code, Codex CLI, Goose, opencode, Aider, Cursor и другими.
+> Он содержит только то, что работает независимо от инструмента.
+> Claude Code-специфика (slash-команды, subagents, advisor) — в `CLAUDE.md`.
+
+## Кто читает что
+
+```mermaid
+graph LR
+    A["AGENTS.md\n(этот файл)\nvendor-neutral"]
+    C["CLAUDE.md\nClaude Code stub\n@AGENTS.md + специфика"]
+
+    A --> Codex["Codex CLI"]
+    A --> Goose["Goose"]
+    A --> OC["opencode"]
+    A --> Aider["Aider / Cursor"]
+    C -- "разворачивает @AGENTS.md\nи добавляет свою специфику" --> CC["Claude Code"]
+    A -.-> CC
+```
+
+Если твой инструмент не понимает `@`-импорты — прочти этот файл напрямую.
+Если понимает — `CLAUDE.md` уже включает его содержимое автоматически.
+
+---
+
+## Где живёт знание (Source of truth)
+
+| Что | Где |
+|---|---|
+| Задачи, спринты | GitHub Issues + Projects v2 |
+| Архитектурные решения | `docs/decisions/` (MADR 4.0) |
+| Доменная модель | `docs/domain/` |
+| Системная архитектура | `docs/architecture/` |
+| Принципы | `docs/principles.md` |
+| Анти-паттерны (ловушки LLM) | `docs/anti-patterns.md` |
+| Процедуры | `docs/runbooks/` |
+
+Голова оператора, память LLM, история чата — **не** источники истины.
+Если знание не зафиксировано в репо — оно потеряется.
+
+---
+
+## Структура репо
+
+```
+docs/
+├── architecture/     — как устроено целиком
+├── decisions/        — ADR: почему принято то или иное решение
+├── domain/           — термины и границы контекстов
+├── principles.md     — девять принципов (контракт)
+├── anti-patterns.md  — ловушки, в которые LLM падает регулярно
+├── runbooks/         — пошаговые сценарии
+└── metrics/          — health-отчёты
+
+bootstrap/
+├── agents/           — read-only AI-критики
+├── commands/         — slash-команды (Claude Code)
+├── hooks/            — commit-governance + форматирование
+├── scripts/          — утилиты
+├── templates/        — шаблоны для новых проектов
+└── universal-setup.sh — идемпотентный установщик
+```
+
+---
+
+## Как запустить / проверить
+
+```bash
+# Проверить что установлено (dry-run)
+./bootstrap/universal-setup.sh --check
+
+# Установить / обновить на этой машине
+./bootstrap/universal-setup.sh --install
+
+# Установить pipeline-команды в конкретный проект
+./bootstrap/universal-setup.sh --target /path/to/project
+
+# Проверить governance hook
+echo "test: something #123" | bash bootstrap/hooks/pre-commit-governance.sh
+```
+
+Скрипт идемпотентен — повторный запуск ничего не сломает.
+
+---
+
+## Как работает пайплайн (workflow)
+
+Каждая задача проходит шесть стадий. Каждая стадия производит конкретный артефакт.
+
+```mermaid
+flowchart LR
+    I["GitHub Issue\n#NNN"] --> P["Plan\nplan.md"]
+    P --> AD{"ADR\nнужен?"}
+    AD -- "да" --> ADR["docs/decisions/\nNNNN-*.md"]
+    ADR --> Im
+    AD -- "нет" --> Im["Implement\nизменения кода/docs"]
+    Im --> QA["QA\nqa-report.md"]
+    QA --> R["Review\n2 голоса"]
+    R --> C["Commit + PR\nCloses #NNN"]
+```
+
+### Что каждая стадия делает
+
+**Plan** — прочитать issue, написать `plan.md` с шестью разделами: формулировка задачи, затронутые файлы, рассмотренные подходы, выбранный подход, стратегия тестирования, риски.
+
+**ADR (если нужен)** — если решение архитектурно значимо (новая зависимость, граница BC, инфраструктура, необратимое ограничение), зафиксировать его в `docs/decisions/NNNN-*.md` по формату MADR 4.0 и смержить отдельным PR до старта реализации.
+
+**Implement** — реализовать план. По ходу: дважды запросить второй голос (независимый review) — перед началом и перед объявлением готовности.
+
+**QA** — прогнать тесты, проверить coverage, убедиться что docs обновлены. Зафиксировать в `qa-report.md`.
+
+**Review** — два независимых review: первый и второй голос. Разногласие между ними → ручное решение оператора. Оба должны одобрить или разногласие задокументировано.
+
+**Commit + PR** — коммит в Conventional Commits формате с issue-ref. PR с `Closes #NNN` и ссылкой на ADR если был.
+
+---
+
+## Жёсткие правила
+
+1. **ADR-PR обязателен** для архитектурно-значимых решений. «Договорились в чате» — не решение.
+2. **Issue-first**: задача длиннее одной сессии — сначала создать issue.
+3. **Cross-ref в PR**: `Closes #NNN` обязателен. `Implements docs/decisions/NNNN-*.md` — если был ADR.
+4. **Conventional Commits**: `type(scope): message`. Governance hook проверяет автоматически.
+5. **Definition of Done** — см. `docs/principles.md`. Merge блокируется до выполнения.
+
+Что считается архитектурно значимым (триггер для ADR) — см. `docs/principles.md#что-значит-архитектурно-значимо`.
+
+---
+
+## Governance hook (commit-msg)
+
+Скрипт `bootstrap/hooks/commit-msg-governance.sh` — это git commit-msg hook. Блокирует коммит если:
+- нет Conventional Commits префикса (`feat:`, `fix:`, `docs:`, `chore:` и т.д.)
+- нет ссылки на issue (`#NNN` или `Closes #NNN`) в сообщении или имени ветки
+- нет ссылки на ADR (`docs/decisions/NNNN-*.md`) для архитектурно значимых изменений
+
+Требует: `bash`, `git`, `jq`.
+
+**Как установить** (один раз на репо; запускать из корня claude-mini):
+
+```bash
+# Вариант A — через Claude Code installer (также прописывает хук в Claude Code settings.json):
+./bootstrap/universal-setup.sh --install
+
+# Вариант B — вручную, без Claude Code:
+cp bootstrap/hooks/commit-msg-governance.sh .git/hooks/commit-msg
+chmod +x .git/hooks/commit-msg
+
+# Проверить:
+echo "feat: add feature #127" > /tmp/msg && bash .git/hooks/commit-msg /tmp/msg
+echo "Exit: $?"  # 0 = OK, 1 = blocked
+```
+
+---
+
+## MCP-серверы
+
+Репо использует три MCP-сервера. MCP (Model Context Protocol) — открытый стандарт, поддерживается Goose, opencode, Cursor и другими клиентами.
+
+| Сервер | Назначение | Когда использовать |
+|---|---|---|
+| **Serena** | Семантическая навигация по коду: поиск символов, их references, структура файла | Вместо grep на больших файлах |
+| **GitHub** | Чтение и запись issues, PR, projects, actions | Для работы с бэклогом и PR |
+| **Context7** | Актуальная документация библиотек (не из training data) | Перед любой гипотезой об API библиотеки |
+
+Конфигурация серверов — в `~/.claude/settings.json` (Claude Code) или в аналогичном config-файле твоего инструмента.
+
+---
+
+## Что уникально в этом репо
+
+Проект документирует и устанавливает сам себя. Каждое изменение — новый агент, новая команда, новый runbook — проходит через собственный pipeline: issue → plan → (ADR?) → implement → review → commit → PR.
+
+Это не стайлинг. Это доказательство: если pipeline не может произвести новый артефакт — pipeline сломан.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,29 +1,18 @@
-# Project conventions — claude-mini
+@AGENTS.md
 
-Этот файл — карта, а не территория. Перечитывай при старте сессии; не кешируй в memory.
+<!-- Claude Code разворачивает @AGENTS.md автоматически.                    -->
+<!-- Другие инструменты и GitHub читают AGENTS.md напрямую.                 -->
 
-## Source of truth
+> **Vendor-neutral инструкции:** [AGENTS.md](AGENTS.md) — структура репо, workflow, правила, hook, MCP.
 
-- **Backlog, milestones, sprints:** GitHub Issues + Projects v2 (этот репо).
-- **Architecture decisions:** `docs/decisions/` (MADR 4.0). Новые — через `/adr`.
-- **Domain model:** `docs/domain/`. Эволюционирует через `domain-researcher`.
-- **System structure:** `docs/architecture/`.
-- **Principles:** `docs/principles.md`.
-- **Anti-patterns:** `docs/anti-patterns.md` (реестр ленивых решений LLM, Принцип 4).
-- **Runbooks:** `docs/runbooks/`.
+# Claude Code — дополнительная конфигурация
 
-## Hard rules
-
-1. **ADR-PR** обязателен для любого архитектурно-значимого решения. «Мы договорились в чате» — не решение.
-2. **Issue-first** для любой задачи длиннее одной сессии. Промоут через `/task-to-issue`.
-3. **Cross-ref в PR** обязателен: `Closes #NNN` и `Implements docs/decisions/NNNN-*.md` если был ADR.
-4. **Conventional Commits.** `pre-commit-governance.sh` hook проверяет префикс и issue-ref.
-5. **Definition of Done** — см. `docs/principles.md#definition-of-done`. Merge блокируется до выполнения.
-6. **Advisor policy:** `advisor()` вызывается дважды на нетривиальную задачу — перед началом работы (проверка плана) и перед объявлением готовности (поиск багов/несоответствий ADR).
+Этот файл добавляет Claude Code-специфику поверх `AGENTS.md`.
+Перечитывай при старте сессии; не кешируй в memory.
 
 ## Orchestration
 
-**Главный цикл:** `claude --model sonnet` с `/advisor` (Opus 4.7 как консультант).
+**Главный цикл:** `claude --model sonnet` с `advisor()` (Opus 4.7 как консультант).
 
 **Feature pipeline (канонический путь):**
 
@@ -67,16 +56,21 @@ Read-only критики. Вызов: `@agent-<name>`.
 
 ## MCP tooling
 
-- **Serena** — семантическая навигация. Используй вместо grep на больших файлах.
-- **GitHub** — issues/PR/projects/actions. Read-only header `X-MCP-Read-Only: true` для exploratory-сессий.
-- **Context7** — актуальная документация библиотек. Проверяй здесь перед гипотезой «API такой».
+Назначение серверов — в `AGENTS.md §MCP-серверы`. Claude Code-специфика:
 
-## Что в этом репо уникально
+- **GitHub** — для exploratory-сессий добавляй `X-MCP-Read-Only: true` header.
+- **Context7** — проверяй здесь перед любой гипотезой об API библиотеки; training data устаревает.
 
-Этот проект документирует и устанавливает сам себя. Каждое изменение (новый агент, новая команда, новый runbook) проходит через собственный pipeline: issue → plan → (ADR если надо) → implement → review → governance-commit → PR. Это не стайлинг — это дисциплина. Если pipeline не умеет произвести новый артефакт, pipeline сломан.
+## Advisor policy
+
+`advisor()` вызывается **дважды** на нетривиальной задаче:
+1. **Перед реализацией** — проверить план, найти дыры до написания кода.
+2. **Перед объявлением готовности** — проверить diff на баги и несоответствия ADR.
+
+Нетривиальная задача: затрагивает >1 модуля, неочевидные edge cases, конкурирует с похожим кодом, содержит асинхронность. Тривиальное (форматирование, rename, однострочный fix) — без advisor.
 
 ## Что не делать
 
-- **Не редактировать `bootstrap/` напрямую в production `~/.claude/`.** Источник правды — этот репо. Глобальные артефакты (agents, skills, hooks): `./bootstrap/universal-setup.sh --install`. Slash-команды — per-project: `./bootstrap/universal-setup.sh --target <repo>`. Порядок миграции важен: сначала `--target <repo>`, затем `rm ~/.claude/commands/*.md` (не наоборот — иначе останешься без команд). (ADR-0018)
-- **Не коммитить напрямую через терминал минуя `/review` и governance.** Для защиты от себя можно включить git-level commit-msg hook (см. `docs/runbooks/enforcement-extras.md` — TODO).
-- **Не вызывать advisor на тривиальное.** Форматирование, переименование, мусорный refactor — без advisor. Он для содержательных решений.
+- **Не редактировать `bootstrap/` напрямую в production `~/.claude/`.** Источник правды — этот репо. Глобальные артефакты: `./bootstrap/universal-setup.sh --install`. Slash-команды — per-project: `./bootstrap/universal-setup.sh --target <repo>`. Порядок важен: сначала `--target <repo>`, затем `rm ~/.claude/commands/*.md`. (ADR-0018)
+- **Не коммитить напрямую через терминал минуя `/review` и governance.**
+- **Не вызывать advisor на тривиальное.** Форматирование, переименование, мусорный refactor — без advisor.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,27 @@ bootstrap/
 
 **Scripts (8):** `mini-preflight`, `mini-session`, `mini-bootstrap-project`, `mini-health`, `review-codex.sh`, `gate-audit-lib.sh` (event-write helper), `gate-audit-aggregate.sh` (weekly aggregation), `forge.sh` (gate-tag CLI).
 
+## AGENTS.md + CLAUDE.md — два файла, два читателя
+
+Репо поддерживает два конфигурационных файла одновременно:
+
+```mermaid
+graph LR
+    A["AGENTS.md\nvendor-neutral"] --> Codex["Codex CLI"]
+    A --> Goose["Goose"]
+    A --> OC["opencode / Aider / Cursor"]
+    C["CLAUDE.md\n@AGENTS.md + специфика"] -- "разворачивает импорт" --> CC["Claude Code"]
+    A -.-> CC
+```
+
+**AGENTS.md** содержит всё vendor-neutral: структуру репо, workflow-стадии, правила, governance hook, MCP-серверы. Написан в формате [AGENTS.md](https://aaif.ai/), совместимом с AAIF-стандартом.
+
+**CLAUDE.md** — тонкий stub. Начинается с `@AGENTS.md` (Claude Code разворачивает импорт автоматически) и добавляет только то, что специфично для Claude Code: slash-команды, таблицу субагентов, advisor policy.
+
+**Если нужно мигрировать на другой инструмент:** большая часть pipeline переносится без усилий. Подробности и пример — `docs/runbooks/vendor-migration.md`.
+
+---
+
 ## Контракт воспроизводимости
 
 - Любой шаг можно пройти повторно без разрушения состояния (`--install` после `--install` ничего не сломает).

--- a/bootstrap/templates/AGENTS.md.template
+++ b/bootstrap/templates/AGENTS.md.template
@@ -1,0 +1,82 @@
+# AGENTS.md — <PROJECT_NAME>
+
+> Этот файл читается любым AI-агентом: Claude Code, Codex CLI, Goose, opencode, Aider, Cursor и другими.
+> Содержит только vendor-neutral инструкции.
+> Claude Code-специфика — в `CLAUDE.md`.
+
+## Где живёт знание
+
+| Что | Где |
+|---|---|
+| Задачи, спринты | GitHub Issues + Projects v2 |
+| Архитектурные решения | `docs/decisions/` (MADR 4.0) |
+| Принципы | `docs/principles.md` |
+| Процедуры | `docs/runbooks/` |
+
+## Структура репо
+
+```
+<!-- Опиши структуру своего проекта -->
+src/
+tests/
+docs/
+```
+
+## Как запустить / тестировать
+
+```bash
+# Установить зависимости
+<!-- команда -->
+
+# Запустить тесты
+<!-- команда -->
+
+# Lint + typecheck
+<!-- команда -->
+```
+
+## Как работает пайплайн
+
+```mermaid
+flowchart LR
+    I["GitHub Issue\n#NNN"] --> P["Plan\nplan.md"]
+    P --> AD{"ADR\nнужен?"}
+    AD -- "да" --> ADR["docs/decisions/\nNNNN-*.md"]
+    ADR --> Im
+    AD -- "нет" --> Im["Implement"]
+    Im --> QA["QA\nqa-report.md"]
+    QA --> R["Review\n2 голоса"]
+    R --> C["Commit + PR\nCloses #NNN"]
+```
+
+Наследует pipeline claude-mini: `/plan → /adr? → /implement → /qa → /review → /codex-review → commit → PR`.
+
+## Жёсткие правила
+
+1. **ADR-PR** обязателен для архитектурно-значимых решений.
+2. **Issue-first** для задач длиннее одной сессии.
+3. **Cross-ref в PR:** `Closes #NNN` + `Implements docs/decisions/NNNN-*.md` если был ADR.
+4. **Conventional Commits.** `pre-commit-governance.sh` hook проверяет.
+5. **DoD** блокирует merge — см. `docs/principles.md`.
+
+## Governance hook
+
+`bootstrap/hooks/pre-commit-governance.sh` блокирует коммит без CC-префикса и issue-ref.
+Установить: `./bootstrap/universal-setup.sh --install` (один раз на репо).
+
+## MCP-серверы
+
+| Сервер | Назначение |
+|---|---|
+| Serena | Семантическая навигация по коду |
+| GitHub | Issues, PR, projects |
+| Context7 | Документация библиотек |
+
+## Специфика проекта
+
+<!-- Опиши что отличается от мастер-соглашений claude-mini.
+Примеры:
+  - Проект на Django, см. ADR-0002
+  - Codex review не применяется (Python, покрывается uv pip audit)
+  - Коммиты в staging без PR (низкий риск)
+-->

--- a/bootstrap/templates/CLAUDE.md.template
+++ b/bootstrap/templates/CLAUDE.md.template
@@ -1,32 +1,23 @@
-# Project conventions — <PROJECT_NAME>
+@AGENTS.md
 
-Наследует соглашения `claude-mini`: pipeline `/plan → /adr? → /implement → /review → /codex-review`, read-only critic agents, governance hook на commits, Definition of Done из `docs/principles.md`.
+<!-- Claude Code разворачивает @AGENTS.md автоматически.                    -->
+<!-- Другие инструменты и GitHub читают AGENTS.md напрямую.                 -->
 
-## Source of truth
+> **Vendor-neutral инструкции:** [AGENTS.md](AGENTS.md) — структура репо, workflow, правила, hook, MCP.
 
-- **Backlog, milestones, sprints:** GitHub Issues + Projects v2 этого репо
-- **Architecture decisions:** `docs/decisions/` (MADR 4.0). Новые — через `/adr`
-- **Domain model:** `docs/domain/`
-- **Principles:** `docs/principles.md` (ссылается на claude-mini master)
-- **Runbooks:** `docs/runbooks/`
+# Claude Code — специфика для <PROJECT_NAME>
 
-## Hard rules
-
-1. **ADR-PR** обязателен для архитектурно-значимых решений
-2. **Issue-first** для задач длиннее одной сессии
-3. **Cross-ref в PR:** `Closes #NNN` + `Implements docs/decisions/NNNN-*.md` если был ADR
-4. **Conventional Commits.** `pre-commit-governance.sh` hook проверяет
-5. **DoD** блокирует merge
-6. **Advisor policy:** `advisor()` × 2 на нетривиальной задаче
+Этот файл добавляет Claude Code-специфику поверх `AGENTS.md`.
+Наследует соглашения `claude-mini`: pipeline, read-only critic agents, governance hook, DoD.
 
 ## Orchestration
 
-Главный цикл: `claude --model sonnet` с `/advisor` (Opus 4.7).
+Главный цикл: `claude --model sonnet` с `advisor()` (Opus 4.7).
 
 Канонический pipeline:
 ```
-/task-to-issue → /plan <N> → /adr (если нужно) → /implement 
-  → /review → /codex-review → git commit → gh pr create
+/task-to-issue → /plan <N> → /adr (если нужно) → /implement
+  → /qa → /review → /codex-review → git commit → gh pr create
 ```
 
 Мастер-оркестратор: `/feature <issue>`.
@@ -37,18 +28,30 @@
 |---|---|
 | `adr-reviewer` | После черновика ADR |
 | `domain-reviewer` | После правки domain docs |
-| `domain-researcher` | Greenfield BC |
+| `domain-researcher` | Greenfield BC или устаревший domain/ |
 | `solutions-architect` | Значимый технический выбор |
-| `backlog-groomer` | Раз в неделю |
-| `security-reviewer` | Перед merge в main |
+| `backlog-groomer` | Раз в неделю (out-of-band) |
+| `security-reviewer` | Перед prod-bound PR |
+| `reliability-reviewer` | Перед prod-bound PR |
 | `docs-reviewer` | Если изменились human-facing docs |
+| `adversarial-critic` | Всегда внутри `/review` |
 
-## Project-specific conventions
+## MCP tooling
 
-<!-- Unique for <PROJECT_NAME>. Опиши что отличается от мастер-соглашений claude-mini. -->
+Назначение серверов — в `AGENTS.md §MCP-серверы` (источник истины). Краткий справочник:
 
-<!-- Примеры:
-  - Этот проект использует Django вместо FastAPI, см. ADR-0002
-  - Коммиты в ветку `staging` разрешены без PR (низкий риск)
-  - Codex review не применяется (python-only, покрывается uv pip audit)
+- **Serena** — семантическая навигация. Используй вместо grep на больших файлах.
+- **GitHub** — issues/PR/projects/actions. Для exploratory-сессий: HTTP header `X-MCP-Read-Only: true`.
+- **Context7** — актуальная документация библиотек.
+
+## Advisor policy
+
+`advisor()` × 2 на нетривиальной задаче: перед реализацией и перед объявлением готовности.
+
+## Специфика проекта (Claude Code)
+
+<!-- Добавь то, что отличается от мастер-соглашений и специфично для Claude Code.
+Примеры:
+  - /codex-review не применяется (Python, покрывается uv pip audit)
+  - Определённые MCP-серверы отключены для этого проекта
 -->

--- a/docs/runbooks/vendor-migration.md
+++ b/docs/runbooks/vendor-migration.md
@@ -1,0 +1,202 @@
+# Runbook: миграция pipeline на другой AI-инструмент
+
+Этот runbook отвечает на вопрос: **что делать, если Claude Code больше недоступен?**
+
+Нет пожара — это план действий на случай если он понадобится. Часть pipeline переносится сразу, часть требует небольшой работы.
+
+---
+
+## Что переносится сразу, без усилий
+
+Три компонента уже vendor-agnostic:
+
+### 1. AGENTS.md — контекст репо
+
+`AGENTS.md` написан по стандарту AAIF (Linux Foundation). Любой современный AI-инструмент читает его нативно:
+
+| Инструмент | Читает AGENTS.md? |
+|---|---|
+| Codex CLI (OpenAI) | ✅ Нативно |
+| Goose (Block) | ✅ Нативно |
+| opencode (sst) | ✅ Нативно |
+| Aider | ✅ Нативно |
+| Cursor | ✅ Нативно |
+| Claude Code | ✅ Через `@AGENTS.md` import в CLAUDE.md |
+
+**Что делать:** просто открыть репо в новом инструменте. Он найдёт AGENTS.md и поймёт структуру, правила и workflow.
+
+### 2. Governance hook — git commit-msg hook
+
+`bootstrap/hooks/commit-msg-governance.sh` — это git commit-msg hook (ADR-0011). Требует `bash`, `git`, `jq`.
+
+**Что делать** (выполнять из корня claude-mini):
+
+```bash
+# Скопировать в целевое репо:
+cp bootstrap/hooks/commit-msg-governance.sh /path/to/project/.git/hooks/commit-msg
+chmod +x /path/to/project/.git/hooks/commit-msg
+
+# Проверить — должен заблокировать сообщение без CC-префикса:
+echo "add something" > /tmp/msg && bash /path/to/project/.git/hooks/commit-msg /tmp/msg
+echo "Exit: $?"  # 1 = заблокировано ✓
+
+# Проверить — должен пропустить корректное сообщение:
+echo "feat: add feature #127" > /tmp/msg && bash /path/to/project/.git/hooks/commit-msg /tmp/msg
+echo "Exit: $?"  # 0 = OK ✓
+```
+
+Хук будет проверять Conventional Commits и issue-refs при каждом коммите, независимо от AI-инструмента.
+
+### 3. MCP-серверы — открытый протокол
+
+MCP (Model Context Protocol) — открытый стандарт. Те же серверы работают в Goose, opencode, Cursor и других клиентах.
+
+**Что делать:** настроить те же три сервера в конфиг-файле нового инструмента:
+
+| Сервер | Что делает | Как подключить |
+|---|---|---|
+| **Serena** | Семантическая навигация по коду | `uvx serena` (Python); восстановить: `uvx --reinstall serena` |
+| **GitHub** | Issues, PR, projects | Официальный [GitHub MCP server](https://github.com/github/github-mcp-server) |
+| **Context7** | Документация библиотек | [Context7 MCP](https://github.com/upstash/context7) — проверь актуальное имя пакета в репо |
+
+> ⚠️ Имена пакетов и команды установки меняются. Перед запуском сверяй с официальным репо инструмента, а не с этим runbook. Unpinned MCP-серверы — риск supply chain (см. `docs/synthesis/2026-04-29-pipeline-restructuring.md §MCP transport security`).
+
+Конкретный синтаксис подключения — в документации твоего инструмента.
+
+---
+
+## Что требует ручной работы
+
+### 4. Skills (slash-команды)
+
+В Claude Code slash-команды — это `.md` файлы в `.claude/commands/`. В других инструментах такого механизма нет, но логика та же: системный промпт, описывающий что делать.
+
+```mermaid
+graph LR
+    subgraph "Claude Code"
+        CC[".claude/commands/plan.md\n→ /plan"]
+    end
+    subgraph "Другой инструмент"
+        OT["Аналог:\nшаблон промпта\nили recipe"]
+    end
+    CC -- "содержит системный промпт\n(читаемый текст)" --> OT
+```
+
+**Что делать:**
+
+1. Открыть `.claude/commands/plan.md` (или другой нужный skill).
+2. Прочитать — это обычный markdown с описанием задачи.
+3. Адаптировать под формат нового инструмента:
+
+| Инструмент | Как реализовать аналог skill |
+|---|---|
+| **Codex CLI** | Добавить секцию `## Workflow: Plan` в AGENTS.md с теми же инструкциями |
+| **opencode** | Аналогично — opencode читает AGENTS.md нативно, можно добавить туда же |
+| **Goose** | Создать recipe в `.goose/recipes/plan.yaml` с тем же промптом |
+| **Aider** | Передать как системный промпт через `--system-prompt` |
+
+Приоритет по ценности: `/feature` (оркестратор) → `/plan` → `/implement` → `/review`. Остальные — по потребности.
+
+### 5. Read-only critic agents (subagents)
+
+В Claude Code агенты — это отдельные Claude Code процессы с read-only tools и специализированным промптом. Паттерн переносим.
+
+```mermaid
+graph LR
+    subgraph "Паттерн агента (везде одинаковый)"
+        P["Промпт из\nbootstrap/agents/*.md"]
+        T["Read-only tools:\nRead, Grep, Glob"]
+        O["Вывод:\nAPPROVE / BLOCK + findings"]
+    end
+    P --> T --> O
+```
+
+**Что делать:**
+
+1. Открыть нужный агент, например `bootstrap/agents/security-reviewer.md`.
+2. Скопировать его системный промпт.
+3. Запустить в новом инструменте с ограниченными правами (только чтение файлов).
+
+Без автоматизации это звучит громоздко, но на практике используется 2-3 агента на PR, и их можно запускать как отдельные запросы к модели с нужным контекстом.
+
+### 6. Advisor pattern (второй голос)
+
+`advisor()` в Claude Code — это вызов более мощной модели (Opus) с полным контекстом сессии.
+
+**Аналог в любом инструменте:**
+
+> Сохрани текущий план/diff в файл. Открой новый чат с более мощной моделью. Попроси: «Прочитай этот план и найди дыры, несоответствия, упущенные edge cases. До 150 слов, нумерованный список.»
+
+Это не автоматически, но это именно то, что делает `advisor()` под капотом — второй, независимый взгляд.
+
+---
+
+## Чего НЕ ждать от миграции
+
+Некоторые вещи сложно портировать без существенной работы:
+
+- **Автоматический context window** — Claude Code передаёт контекст сессии в advisor() автоматически. В других инструментах это ручная работа: собери нужный контекст и передай явно.
+- **TodoWrite / task tracking** — встроенный в Claude Code. Аналог: внешний todo файл или просто GitHub issues.
+- **Automatic agent invocation** — в Claude Code агенты вызываются автоматически по условию. В других инструментах — ручной вызов по тому же условию.
+
+---
+
+## Пример: миграция проекта digest на opencode
+
+Чтобы было конкретно — вот как выглядела бы миграция:
+
+**Шаг 1: Создать AGENTS.md**
+
+```bash
+# В репо digest:
+cp /path/to/digest/CLAUDE.md /path/to/digest/AGENTS.md
+# Содержимое digest/CLAUDE.md уже vendor-neutral —
+# там нет slash-команд, только правила проекта.
+
+# Создать stub CLAUDE.md:
+echo '@AGENTS.md' > /path/to/digest/CLAUDE.md
+echo '' >> /path/to/digest/CLAUDE.md
+echo '<!-- Добавь Claude Code-специфику ниже если нужна -->' >> /path/to/digest/CLAUDE.md
+```
+
+**Шаг 2: Установить governance hook**
+
+```bash
+# Из корня claude-mini:
+cp bootstrap/hooks/commit-msg-governance.sh /path/to/digest/.git/hooks/commit-msg
+chmod +x /path/to/digest/.git/hooks/commit-msg
+```
+
+**Шаг 3: Настроить MCP в opencode**
+
+> ⚠️ Формат конфига opencode и имена пакетов — проверяй в [документации opencode](https://opencode.ai/docs) перед копированием. Пример ниже иллюстративный.
+
+```yaml
+# Пример структуры (схему и путь к файлу — сверь с docs opencode):
+mcp:
+  servers:
+    - name: github
+      # имя пакета: github.com/github/github-mcp-server
+    - name: context7
+      # имя пакета: github.com/upstash/context7
+```
+
+**Шаг 4: Добавить workflow в AGENTS.md**
+
+Скопировать описание стадий pipeline из AGENTS.md claude-mini и адаптировать под digest. opencode прочитает и будет следовать.
+
+**Результат:** 80% pipeline работает. Остаток (agents, advisor pattern) — ручные обращения к модели по мере необходимости.
+
+---
+
+## Итоговая таблица переносимости
+
+| Компонент | Переносится? | Усилие |
+|---|---|---|
+| AGENTS.md контекст | ✅ Сразу | 0 |
+| Governance hook | ✅ Сразу | 5 мин |
+| MCP-серверы | ✅ Сразу | 15 мин |
+| Skills (slash-команды) | ⚠️ Вручную | 1-2 ч на набор |
+| Read-only critic agents | ⚠️ Вручную | 30 мин на агента |
+| Advisor pattern | ⚠️ Вручную | Всегда вручную |
+| TodoWrite / task tracking | ❌ Не переносится | Нужна альтернатива |


### PR DESCRIPTION
## Summary

- Создан `AGENTS.md` с vendor-neutral контентом (структура репо, workflow-стадии, hard rules, governance hook, MCP-серверы) — совместим с AAIF-стандартом, читается Codex CLI, Goose, opencode, Aider, Cursor
- `CLAUDE.md` переписан как stub: `@AGENTS.md` + Claude Code-специфика (slash-команды, agents table, advisor policy)
- `bootstrap/templates/CLAUDE.md.template` → stub-паттерн; `AGENTS.md.template` создан для новых проектов
- `docs/runbooks/vendor-migration.md` — руководство по миграции pipeline на другой AI-инструмент (hook, MCP, skills, agents, advisor)
- `README.md` — секция о duality с Mermaid-диаграммой

## QA

**Carve-out:** docs-only diff. Все изменённые файлы — `*.md`. Стандартная проверка test coverage не применяется.

**Structural checks:** все пройдены (AGENTS.md 7 секций ✓, CLAUDE.md starts with @AGENTS.md ✓, templates ✓, runbook ✓, README ✓).

**Tests:** No test harness for markdown-only changes. Escape hatch applied.

**Smoke test (после merge, вручную):** открыть новую Claude Code сессию, убедиться что раздел «Где живёт знание» из AGENTS.md виден в контексте (механизм `@`-импорта подтверждён — `~/.claude/CLAUDE.md` использует тот же паттерн в этой сессии).

## Review notes

- Two-voice review: Claude + Codex **agreed**, no BLOCK findings after fixes
- Исправлено в процессе review: неправильный хук (`pre-commit-governance` → `commit-msg-governance`), fabricated Serena npm package (`→ uvx serena`), отсутствие clickable fallback link для GitHub-рендеринга
- Digest и другие проекты мигрируются отдельными тикетами по паттерну из runbook

Closes #127
Implements docs/principles.md (Принцип 7)