### PR TITLE
feat(bootstrap): add AGENTS.md + CLAUDE.md templates to --target installer #182

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ bootstrap/
 ├── commands/           — slash-commands для ~/.claude/commands/
 ├── hooks/              — Claude Code hooks (PreToolUse + PostToolUse + Stop) для ~/.claude/hooks/
 ├── scripts/            — утилиты для ~/.claude/scripts/ и ~/bin/
-├── templates/          — шаблоны (CLAUDE.md, PR template, CI workflows)
+├── templates/          — шаблоны (AGENTS.md, CLAUDE.md, PR template, CI workflows)
 └── universal-setup.sh  — идемпотентный installer
 ```
 

--- a/bootstrap/scripts/test-install-verification.sh
+++ b/bootstrap/scripts/test-install-verification.sh
@@ -160,11 +160,11 @@ else
     fail "--target cp line missing || die guard"
 fi
 
-# ---- Gap #4 (ADR-0023): --target delivers four new template files ----
+# ---- Gap #4: --target delivers all expected template files ----
 echo ""
-echo "Gap #4: --target delivers ADR-0023 template files (structural + functional)"
+echo "Gap #4: --target delivers template files (structural + functional)"
 
-for f in "ruff.toml" ".eslintrc.json" ".jscpd.json"; do
+for f in "ruff.toml" ".eslintrc.json" ".jscpd.json" "AGENTS.md" "CLAUDE.md"; do
     if grep -q "\"$f\"" "$SETUP" 2>/dev/null || grep -q "/$f" "$SETUP" 2>/dev/null; then
         pass "--target section references $f"
     else
@@ -177,10 +177,10 @@ else
     fail "--target section missing .semgrep/llm-antipatterns.yaml"
 fi
 
-# Functional: run --target against a temp dir and verify all four files land
+# Functional: run --target against a temp dir and verify all six files land
 _T=$(mktemp -d /tmp/claude-mini-verify-templates-XXXXXX)
 if bash "$SETUP" --target "$_T" >/dev/null 2>&1; then
-    for f in "ruff.toml" ".eslintrc.json" ".jscpd.json" ".semgrep/llm-antipatterns.yaml"; do
+    for f in "ruff.toml" ".eslintrc.json" ".jscpd.json" ".semgrep/llm-antipatterns.yaml" "AGENTS.md" "CLAUDE.md"; do
         if [ -f "$_T/$f" ]; then
             pass "--target functional: $_T/$f created"
         else

--- a/bootstrap/templates/AGENTS.md.template
+++ b/bootstrap/templates/AGENTS.md.template
@@ -1,4 +1,4 @@
-# AGENTS.md — <PROJECT_NAME>
+# AGENTS.md
 
 > Этот файл читается любым AI-агентом: Claude Code, Codex CLI, Goose, opencode, Aider, Cursor и другими.
 > Содержит только vendor-neutral инструкции.

--- a/bootstrap/templates/CLAUDE.md.template
+++ b/bootstrap/templates/CLAUDE.md.template
@@ -5,7 +5,7 @@
 
 > **Vendor-neutral инструкции:** [AGENTS.md](AGENTS.md) — структура репо, workflow, правила, hook, MCP.
 
-# Claude Code — специфика для <PROJECT_NAME>
+# Claude Code — дополнительная конфигурация
 
 Этот файл добавляет Claude Code-специфику поверх `AGENTS.md`.
 Наследует соглашения `claude-mini`: pipeline, read-only critic agents, governance hook, DoD.

--- a/bootstrap/universal-setup.sh
+++ b/bootstrap/universal-setup.sh
@@ -254,6 +254,18 @@ if [ -n "$TARGET_PATH" ]; then
         "$TARGET_DIR/.semgrep/llm-antipatterns.yaml" \
         ".semgrep/llm-antipatterns.yaml"
 
+    # AGENTS.md (#182: AAIF vendor-neutral template; no ADR — below architectural significance threshold)
+    _copy_template \
+        "$REPO_ROOT_T/bootstrap/templates/AGENTS.md.template" \
+        "$TARGET_DIR/AGENTS.md" \
+        "AGENTS.md"
+
+    # CLAUDE.md (#182: Claude Code stub that imports AGENTS.md; no ADR — same rationale)
+    _copy_template \
+        "$REPO_ROOT_T/bootstrap/templates/CLAUDE.md.template" \
+        "$TARGET_DIR/CLAUDE.md" \
+        "CLAUDE.md"
+
     echo ""
     log "Done (target mode, pipeline v$PIPELINE_VERSION)"
     if [ "$DRIFT" -gt 0 ]; then

--- a/docs/runbooks/onboarding-repo.md
+++ b/docs/runbooks/onboarding-repo.md
@@ -25,18 +25,19 @@ cd ~/projects/claude-mini
 ```
 
 Проверь:
+- [ ] Есть ли `AGENTS.md`?
 - [ ] Есть ли `CLAUDE.md`?
 - [ ] Есть ли `docs/decisions/`?
 - [ ] Есть ли `docs/principles.md`?
 - [ ] Настроены ли GitHub labels?
 - [ ] Есть ли PR template?
 
-### 2. Добавить CLAUDE.md
+### 2. Кастомизировать AGENTS.md и CLAUDE.md
 
-```bash
-cp ~/.claude/templates/claude-mini/CLAUDE.md.template CLAUDE.md
-# Отредактируй: замени <PROJECT_NAME>, добавь project-specific правила
-```
+`--target` (шаг 1) доставляет оба файла автоматически. Отредактируй под проект:
+
+- **AGENTS.md** — добавь реальную структуру репо, команды сборки/тестирования, project-specific правила.
+- **CLAUDE.md** — добавь Claude Code-специфику в раздел "Специфика проекта" если нужна.
 
 ### 3. Добавить principles.md
 


### PR DESCRIPTION
## Summary

- `universal-setup.sh --target <repo>` now delivers `AGENTS.md` and `CLAUDE.md` alongside the existing pipeline templates (conftest.py, ruff.toml, etc.)
- `<PROJECT_NAME>` placeholder removed from both template headers — prevents permanent `cmp -s` drift after operator customisation
- `test-install-verification.sh` Gap #4 extended: structural + functional assertions for both new files
- `docs/runbooks/onboarding-repo.md` updated: stale manual `cp` instruction replaced with "delivered automatically by `--target`"

Closes #182
Follows named-exception pattern from ADR-0022 and ADR-0023.

## QA

**Tests:** All changed paths covered. `bootstrap/universal-setup.sh` — new `_copy_template` calls for AGENTS.md and CLAUDE.md are exercised by the extended Gap #4 in `test-install-verification.sh`: structural grep checks and functional `--target` run both pass (6 files verified, idempotent re-run: no drift). ShellCheck clean on both changed `.sh` files. `test-install-verification.sh` is the established test harness for `universal-setup.sh` — no separate test for the harness itself (repo pattern).

**Docs:** Two updates made during /implement and /qa:
- `docs/runbooks/onboarding-repo.md` §1+§2 — replaced stale manual `cp ~/.claude/templates/…CLAUDE.md.template` instruction (wrong path, stale `<PROJECT_NAME>` placeholder ref) with "delivered automatically by `--target`, customize". Added `AGENTS.md` to §1 checklist.
- `README.md` — updated `templates/` description from `(CLAUDE.md, PR template, CI workflows)` to `(AGENTS.md, CLAUDE.md, PR template, CI workflows)`.

## Two-voice review

| Voice | Verdict | Notes |
|---|---|---|
| Claude `/review` | APPROVE | plan §2/§6 wording inconsistency — SUGGEST (cosmetic) |
| `security-reviewer` | APPROVE | symlink pre-existing NIT — not introduced by this PR |
| `reliability-reviewer` | APPROVE | inline recovery comment SUGGEST — pre-existing on all 7 `_copy_template` calls |
| `adversarial-critic` | APPROVE | comment cited PR# → updated to issue# + rationale |
| Codex `/codex-review` | APPROVE | BLOCK fixed (Gap #4 header ADR ref removed); `<PROJECT_NAME>` removal concern addressed in plan.md §6 Risk #2 |

**Two-voice disagreement:** Codex SUGGEST 1 — "policy rationale in comments is brittle, prefer issue-ref only". Kept the explanation: the comment was already changed from opaque `PR #181` to `(#182: AAIF vendor-neutral template; no ADR — below architectural significance threshold)` per adversarial-critic guidance; removing the explanation would regress. Disagreement documented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)