### PR TITLE
docs(adr): introduce Session Continuity BC and STATE.md schema #128

### DIFF
--- a/docs/decisions/0024-session-continuity-bc-and-state-schema.md
+++ b/docs/decisions/0024-session-continuity-bc-and-state-schema.md
@@ -1,0 +1,501 @@
+# 0024. Establish Session Continuity as a sibling bounded context with `STATE.md` as document-model aggregate root
+
+* Status: proposed
+* Superseded-by: ~
+* Date: 2026-05-03
+* Deciders: Lenivvenil (operator decides; draft by solutions-architect)
+* Tags: domain, bounded-context, session-continuity, state-schema, continuity
+* Related issue: #128
+
+## Context and Problem Statement
+
+Principle 9 (`docs/principles.md#9-перехват--контракт`) requires that an
+operator (or fresh agent) can open the repo after an LLM session ends and
+resume meaningful work within five minutes — the "Human Resume Test". Today
+this is impossible: there is no `STATE.md`, no structured session-log, and
+no linter that enforces ADR-discipline on `plan.md`. Issue #128 introduces
+all three artifacts simultaneously, and the artifacts collectively span a
+concern — what survives between sessions — that does not belong inside any
+existing aggregate of bounded context `claude-mini-pipeline`.
+
+The decision is architecturally significant per
+`docs/principles.md#что-значит-архитектурно-значимо`: four triggers fire at
+once — (1) a new bounded-context boundary, (2) a cross-BC contract
+(`active_feature_run_id` reference into `claude-mini-pipeline`), (3) a data
+model (`STATE.md` 9-field schema) that becomes hard to change once
+distributed via `--target` to consumer repos, and (4) a new cross-cutting
+tool dependency (`plan-lint.sh`) installed into every target repo. The
+`domain-researcher` discovery doc at `docs/domain/continuity-discovery.md`
+has surfaced the proposed Ubiquitous Language extension and the Bounded
+Context Canvas; this ADR records the boundary call and the schema choices
+that the discovery doc deliberately left open.
+
+## Decision Drivers
+
+* **Principle 9 contract.** Hand-off must be readable without LLM, in five
+  minutes, from artifacts on disk. The BC's primary NFR (`Human Resume
+  Test`) is the binding constraint; every schema choice is judged against
+  it.
+* **ADR-0020 cross-aggregate pattern must hold.** `FeatureRun` was already
+  split (ADR-0020) precisely to avoid embedding orthogonal lifecycles in
+  one aggregate. A new lifecycle (`Session`) with its own boundaries must
+  not regress that decision.
+* **Principle 8 — 2-3× margin, not 1000×.** The current scale is one
+  operator, low-frequency hand-offs, single-repo. Event-sourcing,
+  structured-log machinery, and atomic write protocols are
+  over-engineering at this scale; document model with replacement
+  semantics is sufficient.
+* **Principle 3 — deterministic tooling first.** Mechanical invariants
+  (`STATE.md` size cap, append-only, one-file-per-day) must be checkable
+  by `wc`, `grep`, and `test`, not by an agent.
+* **Documentation-only cost.** This ADR records boundary and schema; the
+  implementation cost is bash plumbing in the existing `stop-hook.sh` and
+  one new `plan-lint.sh` script. No production code, no migration.
+* **Distribution to target repos via `--target`.** `STATE.md.template` and
+  `plan-lint.sh` will be installed into consumer repos. Schema changes
+  after distribution are migration events; the schema must therefore be
+  cheap-to-change-now and load-bearing-after-merge.
+
+## Considered Options
+
+* **Approach A — Embed session state in `FeatureRun`.** Add `session_id`,
+  `next_3_actions`, `blocked_on`, etc. as attributes of the existing
+  `FeatureRun` aggregate root inside `claude-mini-pipeline`. `stop-hook`
+  reads the active `FeatureRun`, writes `STATE.md` as a projection. One
+  aggregate, minimum new documentation.
+* **Approach B1 — Sibling BC `Session Continuity`; `STATE.md` as
+  document-model aggregate root.** New BC. `STATE.md` is the aggregate
+  root with nine fields. `session-log` is an append-only entity.
+  `active_feature_run_id` is a reference-only cross-BC pointer into
+  `claude-mini-pipeline`. Document model: replace on hand-off, no event
+  store.
+* **Approach B2 — Sibling BC `Session Continuity`; `Session` as event-sourced
+  aggregate root, `STATE.md` as projection.** Same BC boundary as B1, but
+  `Session` is the aggregate root, `session-log` entries are its event
+  stream, and `STATE.md` is a derived current-state projection. Cleaner
+  DDD semantics; event-store overhead.
+* **Approach C — Linter as part of `/plan` skill, not hand-off.** `plan.md`
+  ADR-discipline check runs at plan generation time only, owned by the
+  `/plan` slash command in `claude-mini-pipeline`. No invocation from
+  Session Continuity. Two-leg hand-off contract (STATE.md + session-log)
+  instead of triple.
+
+## Decision Outcome
+
+Chosen option: **Approach B1 — Session Continuity as a sibling bounded
+context, with `STATE.md` as a document-model aggregate root and
+`active_feature_run_id` as a reference-only cross-BC pointer into
+`claude-mini-pipeline`.**
+
+A and B1 differ on whether session lifecycle deserves its own bounded
+context. They have non-overlapping lifecycles: a single session may span
+zero, one, or several `FeatureRun`s; a single `FeatureRun` typically spans
+several sessions. ADR-0020 extracted `GovernanceRun` and `TwoVoiceReview`
+out of `FeatureRun` for exactly this reason — orthogonal lifecycles do not
+belong in one aggregate. Folding session state into `FeatureRun` would
+re-create the God Aggregate problem ADR-0020 just resolved, regardless of
+how few attributes are added today. The `domain-researcher` discovery doc
+arrived at the same conclusion independently
+(`docs/domain/continuity-discovery.md` §"Why a new BC").
+
+B1 and B2 differ on the modelling weight of `Session`. B2 is theoretically
+cleaner: `Session` as aggregate root with `STATE.md` as a projection over
+its event stream maps onto event-sourcing without seams. B1 wins on
+Principle 8: at the current scale (one operator, low-frequency hand-offs)
+event-sourcing's overhead — projection logic, event schema versioning,
+replay infrastructure — does not pay for itself. The document model is one
+file with nine fields, replaceable atomically by a single shell-write. If
+session-log later grows into structured machine-parseable events, B2
+becomes the migration target; the present ADR does not foreclose that.
+
+C is rejected because plan content drifts after generation: an operator
+adds design decisions to `plan.md` mid-session without re-running the
+generator. ADR-discipline must be enforced at hand-off boundary, not only
+at plan-generation boundary. The discovery doc flagged this seam (Red
+Hotspot #1); locating the linter invocation in Session Continuity (with
+the rule definition still owned by `claude-mini-pipeline`) keeps both
+sides honest.
+
+This invokes Principle 8 (document model is the 2-3× margin choice;
+event-sourcing would be the 1000× choice) and Principle 9 (the entire BC
+exists to satisfy the hand-off contract Principle 9 mandates). It applies
+the cross-aggregate communication pattern established by ADR-0020 to a
+cross-BC reference: Session Continuity reads `FeatureRun.dod_state` and
+`FeatureRun.issue_ref` by ID; it never commands `claude-mini-pipeline`.
+
+### Sub-decisions recorded explicitly
+
+For traceability — `adr-reviewer` should be able to locate each:
+
+1. **BC placement: sibling, not sub-aggregate.** Session Continuity is a
+   bounded context peer to `claude-mini-pipeline`, not a sub-aggregate
+   inside it. Rationale: orthogonal lifecycles per ADR-0020. Rejected
+   alternative: Approach A (embed in `FeatureRun`).
+
+2. **Aggregate root: `STATE.md` (document model).** `STATE.md` is the
+   aggregate root; `Session` is an attribute (`session_id`) of it.
+   Rationale: Principle 8. Rejected alternative: Approach B2
+   (event-sourced `Session` with `STATE.md` as projection).
+
+3. **Cross-BC reference pattern: `active_feature_run_id` is a pointer,
+   not an embedded copy.** Session Continuity reads `FeatureRun.dod_state`
+   and `FeatureRun.issue_ref` by ID at snapshot time; it does not mirror
+   or cache those attributes. The relationship type is **Customer/Supplier**
+   (Session Continuity is customer; `claude-mini-pipeline` is supplier of
+   run state). Pattern source: ADR-0020 cross-aggregate communication.
+
+4. **`session_id` format: UTC ISO-8601 timestamp** (e.g.,
+   `2026-05-03T14:32:00Z`). Rationale: human-readable, sortable, no
+   external dependency (no ULID library, no git operation required).
+   Rejected alternatives: ULID (collision-resistant but opaque), git-style
+   short hash (collision-prone at low cardinality), operator-typed string
+   (no uniqueness guarantee).
+
+5. **session-log entry order: newest-at-bottom.** True append; new entries
+   are appended to the file end. Rationale: matches the append-only
+   invariant mechanically — a pre-commit check can verify by `diff
+   --unified=0` that only trailing additions exist. Rejected alternative:
+   newest-at-top (more journal-like reading, but every new entry rewrites
+   the file head, breaking mechanical append-only enforcement).
+
+6. **plan.md linter scope: active branches only, not git history.**
+   `plan-lint.sh` runs against `plan.md` on the current branch at hand-off
+   time. Historic `plan.md` files in old commits are not in scope and are
+   not retroactively gated. Rationale: linter is a hand-off-time check;
+   historic plans are not being handed off. The invocation is owned by
+   Session Continuity (when to run); the rule definition (what counts as
+   a design decision and how ADR-ref is asserted) stays in
+   `claude-mini-pipeline`. Resolves discovery Red Hotspot #1.
+
+7. **session-log entry format: markdown prose, not YAML.** Each entry is
+   a human-readable narrative paragraph or bullet list. Rationale:
+   Principle 8 — structured machine parsing of session-log is not a
+   current consumer requirement; the current consumer is a human (or LLM
+   reading natural language) trying to resume. Rejected alternative:
+   YAML front-matter + structured fields (premature; would force schema
+   decisions before there is a parser to break).
+
+8. **session-log and `events.jsonl` (gate-audit) remain separate,
+   intentionally.** Different consumers (human resume vs. ROI analysis),
+   different formats (markdown narrative vs. structured JSONL),
+   different append-only mechanisms. No unification planned. Resolves
+   discovery Red Hotspot #4. Rejected alternative: a single unified
+   append-only event log; rejected because consumer requirements are
+   genuinely orthogonal and unifying the schemas would require forcing
+   one of them to accept the other's format.
+
+9. **Stale `STATE.md` detection: WARNING-only at this stage.** When
+   `stop-hook` writes a snapshot whose operator-asserted fields
+   (`next_3_actions`, `blocked_on`, `open_questions`, `risk_flags`)
+   contain TODO placeholders, the hook logs a WARNING line to
+   `stop.log`. It does not block. Rationale: hard-block requires
+   detection logic that reliably distinguishes "operator chose to leave
+   field empty as a valid empty state" (e.g., `risk_flags: []`) from
+   "operator did not fill it in"; that disambiguation is not yet
+   designed. Hard-block is recorded as a follow-up. Resolves discovery
+   Red Hotspot #7 with explicit deferral. Rejected alternative: hard-
+   block on TODO placeholders; rejected because false-positives on
+   legitimately-empty fields would degrade the pipeline more than the
+   silent-failure risk degrades it today.
+
+### Cross-BC communication
+
+Session Continuity holds `active_feature_run_id` as a reference-only
+pointer into `claude-mini-pipeline`. Concretely:
+
+* When `STATE.md` is written, `active_feature_run_id` records the GitHub
+  issue number of the in-flight `FeatureRun` (or `null`).
+* When `STATE.md` is read by a resuming session, the reader resolves the
+  reference by reading the issue and (if needed) the live `FeatureRun`
+  state in `docs/domain/` — Session Continuity does not duplicate
+  `FeatureRun` state.
+* Session Continuity emits no commands into `claude-mini-pipeline`. It
+  consumes pipeline events (`FeaturePipelineStarted`, `DoDSatisfied`,
+  `AdvisorReturned`) to know when to update its own snapshot, but it
+  does not call back.
+* If `active_feature_run_id` resolves to a closed/deleted/reopened issue
+  (discovery Red Hotspot #8, undefined), the snapshot stays as recorded;
+  resume logic surfaces a "stale reference" warning. The exact warning
+  mechanism is implementation detail for `/implement`, not this ADR.
+
+### Scope of artifacts (what this ADR commits to)
+
+Inside Session Continuity BC, after `/implement`:
+
+* `STATE.md` exists at repo root with nine fields: `session_id`,
+  `date_iso`, `current_branch`, `last_commit_sha`,
+  `active_feature_run_id`, `next_3_actions`, `blocked_on`,
+  `open_questions`, `risk_flags`. Cap ≤200 lines.
+* `session-log/YYYY/MM/YYYY-MM-DD.md` exists with one file per UTC day,
+  newest entry at bottom, markdown prose format.
+* `docs/domain/session-continuity/overview.md` exists with the BC Canvas
+  derived from `continuity-discovery.md`.
+* `docs/domain/vocabulary.md` is extended with the 15 UL terms enumerated
+  in `continuity-discovery.md` §"Ubiquitous Language extension".
+* `bootstrap/scripts/plan-lint.sh` exists, grep-based, run by
+  `stop-hook.sh`.
+* `bootstrap/templates/STATE.md.template` exists for `--target`
+  installation.
+* `docs/runbooks/resume-drill.md` exists with the Human Resume Test
+  procedure.
+
+### Positive Consequences
+
+* `Session`, `STATE.md`, `session-log`, `Hand-off`, `Triple Hand-off
+  Contract`, `Resume`, `Continuity`, and `Human Resume Test` become
+  first-class nouns in the Ubiquitous Language, available for citation
+  from runbooks, ADRs, and PR text.
+* `FeatureRun`'s aggregate surface stays at its post-ADR-0020 size; the
+  recently-resolved God Aggregate problem does not regress.
+* Mechanical invariants are checkable without LLMs: `wc -l STATE.md` for
+  size cap, `grep` for ADR-ref in `plan-lint.sh`, file-existence checks
+  for daily session-log entries.
+* The cross-BC reference pattern is consistent with ADR-0020's
+  cross-aggregate pattern; future readers see one pattern, not two.
+* Document model is reversible: if usage data later justifies B2,
+  migration is a structured re-write of existing `STATE.md` history into
+  events, not a model overhaul.
+
+### Negative Consequences
+
+* **Cross-BC reference resolution failure is undefined.** If
+  `active_feature_run_id` points at a closed, reopened, or deleted issue,
+  the resume behaviour is "snapshot stays as recorded plus a warning" —
+  the warning mechanism, location, and severity are not specified by
+  this ADR. Discovery Red Hotspot #8 is left open.
+* **STATE.md replacement is non-atomic with respect to session-log
+  append.** `stop-hook` writes session-log first, then replaces
+  `STATE.md`; if interrupted between the two, the next session sees a
+  fresh log entry pointing at a stale snapshot. Plan §6 risk #3 records
+  this; mitigation is order-of-operations (log first, snapshot second),
+  not atomicity.
+* **WARNING-only stale detection is a documented compromise.** Sub-
+  decision 9 explicitly chooses warning over hard-block. Operators who
+  ignore WARNING lines in `stop.log` will silently degrade the Human
+  Resume Test. Hard-block is a follow-up, not protection delivered by
+  this ADR.
+* **Document model forecloses event-sourcing migration cheaply only as
+  long as session-log stays prose.** If the log later acquires structure
+  (sub-decision 7 reversed), every prose entry becomes a migration
+  artefact requiring a parser. The cheapness of "B1 → B2 later" is
+  conditional on sub-decision 7 holding.
+* **Newest-at-bottom imposes a readability cost on every resume.** The
+  reader must scroll past prior entries to reach the most recent. This
+  is the stated cost of choosing mechanical append-only enforcement
+  (sub-decision 5) over journal-like readability.
+* **Markdown prose is not machine-parseable.** ROI analysis,
+  cross-session aggregation, and structured queries over session history
+  are not possible without a YAML/JSONL migration. Sub-decision 7
+  records this trade-off intentionally.
+* **Linter scope active-branches-only means historic plans escape.**
+  `plan.md` files in older commits that lack ADR-ref discipline will
+  never be linted. This is recorded scope (sub-decision 6), not a
+  feature; it limits the linter's audit value.
+* **Two intentionally-separate append-only logs (`session-log` and
+  `events.jsonl`) must be maintained forever.** Sub-decision 8 commits
+  to non-unification. The cost is two append-only mechanisms, two
+  on-disk formats, two consumer audiences — and the discipline to keep
+  them from drifting toward overlap.
+* **Latent enforcement.** This ADR records the boundary and schema; the
+  protection only materialises after `/implement` lands the BC overview,
+  vocabulary entries, scripts, templates, and runbook. Between this
+  ADR's merge and the implementation PR's merge, the BC is named but
+  unmaterialised.
+* **Three aggregate roots in `claude-mini-pipeline` plus `STATE.md` in
+  Session Continuity is more documented surface than one aggregate
+  ever was.** Total cognitive entry cost for new contributors rises
+  with each extraction; this ADR adds another root and another BC.
+
+## Pros and Cons of the Options
+
+### Approach A — Embed session state in `FeatureRun`
+
+* Good, because no new BC and no new vocabulary terms; one aggregate to
+  reason about.
+* Good, because `stop-hook` reads `FeatureRun` directly without
+  cross-aggregate query plumbing.
+* Bad, because session lifecycle and `FeatureRun` lifecycle are
+  orthogonal; one session spans many `FeatureRun`s and vice versa.
+  Embedding forces an artificial 1:1 mapping that does not exist.
+* Bad, because it re-creates the God Aggregate problem ADR-0020
+  resolved less than two weeks ago. The pipeline's recent modelling
+  discipline would regress for the sake of avoiding a new BC.
+* Bad, because `STATE.md` content includes data not derivable from any
+  single `FeatureRun` (`open_questions`, `risk_flags`, prose narrative).
+  Forcing those into `FeatureRun` attributes pollutes its invariants.
+
+### Approach B1 — Sibling BC; `STATE.md` as document-model aggregate root
+
+* Good, because lifecycle separation is honest: `Session` and
+  `FeatureRun` belong to different bounded contexts because they are
+  different things.
+* Good, because the cross-BC reference pattern reuses ADR-0020 — one
+  pattern for cross-aggregate AND cross-BC reads.
+* Good, because document model means mechanical invariants (`wc -l`,
+  `grep`) are sufficient — no projection logic, no event store, no
+  replay infrastructure. Principle 3 satisfied directly.
+* Good, because rollback to A is a delete; rollback from B2 to B1 is a
+  schema migration. Choosing B1 first preserves optionality.
+* Bad, because three roots in the pipeline plus a new BC root is more
+  documentation surface than the project had a month ago.
+* Bad, because document model forecloses cheap event-sourcing migration
+  only while session-log stays prose; if the log structures, the cost
+  reappears.
+* Bad, because operator-asserted fields (`next_3_actions`, `blocked_on`,
+  etc.) cannot be inferred mechanically — silent omissions degrade the
+  Human Resume Test, and the warning-only mitigation is documented
+  weakness, not strength.
+
+### Approach B2 — Sibling BC; `Session` as event-sourced aggregate root
+
+* Good, because event-sourcing is the modeling-purist choice: every
+  hand-off is an event, `STATE.md` is a deterministic projection,
+  history is reconstructible by replay.
+* Good, because session-log entries become structured events natively;
+  no separate "log vs event" question (Red Hotspot #4 dissolves).
+* Bad, because event-sourcing infrastructure (event schema versioning,
+  projection rebuilds, replay tooling) costs far more than the current
+  scale justifies. Principle 8 violated by 100×.
+* Bad, because the projection logic introduces a new failure surface:
+  `STATE.md` can be wrong-but-reconstructible, where in B1 it is the
+  source of truth and either right or absent.
+* Bad, because the operator's mental model of "open the file, read it,
+  resume" requires no projection step in B1 — the file is the model. In
+  B2 the operator either trusts the projection or learns to replay.
+
+### Approach C — Linter as part of `/plan` skill, not hand-off
+
+* Good, because linter ownership is uncontested: it lives where plans
+  are generated; no cross-BC seam (Red Hotspot #1 dissolves).
+* Good, because two-leg hand-off contract (STATE.md + session-log) is
+  simpler to explain than triple.
+* Bad, because plans drift after generation. Operators and agents add
+  design decisions to `plan.md` mid-session; without hand-off-time
+  re-check, ADR-discipline gaps accumulate undetected until review.
+* Bad, because hand-off is the meaningful enforcement boundary: review
+  happens after hand-off, and Codex / external reviewers consume the
+  plan as part of context. Letting drift through hand-off defeats the
+  artifact.
+* Bad, because the cross-BC seam (rule in pipeline, invocation in
+  Session Continuity) is the honest model — owning the rule and the
+  invocation in one BC pretends a coupling that exists between two BCs
+  is internal to one.
+
+## Confirmation
+
+After this ADR is accepted and `/implement` lands the corresponding
+artifacts, the following are concretely verifiable:
+
+1. **`docs/domain/session-continuity/overview.md` exists** containing the
+   Bounded Context Canvas (Purpose, Strategic classification,
+   Responsibilities, Not-responsibilities, Inbound events, Outbound
+   events, Collaborators, Distance from core) per
+   `continuity-discovery.md`.
+2. **`docs/domain/vocabulary.md` contains the 15 UL terms** listed in
+   `continuity-discovery.md` §"Ubiquitous Language extension"
+   (`active_feature_run_id`, `blocked_on`, `Continuity`, `Hand-off`,
+   `Human Resume Test`, `next_3_actions`, `open_questions`, `plan.md
+   Linter`, `Resume`, `risk_flags`, `Session`, `session-log`,
+   `session_id`, `STATE.md`, `Triple Hand-off Contract`).
+3. **`STATE.md` exists at repo root with the nine specified fields**,
+   `wc -l STATE.md` returns ≤200, all fields present (empty values
+   `null` or `[]` are valid; missing keys are not).
+4. **`session-log/YYYY/MM/YYYY-MM-DD.md` exists** for the current UTC
+   day at hand-off time, with newest entry appended at bottom in
+   markdown prose.
+5. **`bootstrap/scripts/plan-lint.sh` exists**, is bash, uses only `grep`
+   / `awk` / `test` (no LLM), and exits non-zero when `plan.md` §3 or §4
+   contains a design-decision line without an `ADR-ref` or an explicit
+   `"no ADR — justification: ..."` token.
+6. **`bootstrap/templates/STATE.md.template` exists** and is included in
+   `bootstrap/universal-setup.sh`'s named-exception list, so `--target`
+   installs the template into consumer repos.
+7. **`bootstrap/hooks/stop-hook.sh` updates STATE.md mechanical fields
+   and appends to session-log**, in that order (log first, snapshot
+   second) per Negative Consequence "STATE.md replacement is non-atomic".
+   When operator-asserted fields contain TODO placeholders, hook logs a
+   WARNING line to `stop.log` (sub-decision 9).
+8. **`docs/runbooks/resume-drill.md` exists** with Level 1 (5-minute
+   gate) and Level 2 (1–2 hour onboarding-task gate) procedures from
+   `plan.md` §5.
+9. **`bootstrap/agents/domain-reviewer.md` is updated** to enumerate
+   Session Continuity as a fourth distinct check item alongside
+   `FeatureRun`, `GovernanceRun`, and `TwoVoiceReview` invariant tables.
+   Without this, the structural protection of the new BC is latent —
+   the same pattern ADR-0020 documented for its three roots.
+10. **Cross-BC reference pattern is documented in
+    `docs/domain/session-continuity/overview.md`**: Session Continuity
+    reads `FeatureRun` state by ID; never commands `claude-mini-pipeline`.
+    The pattern citation is to ADR-0020.
+
+## Re-visit Trigger
+
+Re-open this decision when **any one** is true:
+
+* **Stale STATE.md WARNING fires often enough that hard-block becomes
+  necessary.** Threshold: WARNING in `stop.log` on >20% of hand-offs over
+  a 4-week window. Drives reversal of sub-decision 9 (and likely a
+  follow-up ADR for the disambiguation logic between "valid empty" and
+  "operator skipped").
+* **Session-log volume or structure demands YAML / JSONL.** Threshold:
+  any external consumer (an aggregator, a metric script, an agent
+  doing ROI analysis) requests structured fields from session-log; or
+  session-log files routinely exceed 1000 lines per day. Drives reversal
+  of sub-decision 7.
+* **`session-log` and `events.jsonl` prove to be the same family.**
+  Threshold: a feature requires querying both as one stream, or schema
+  drift between them produces a contradiction. Drives reversal of
+  sub-decision 8 (unification ADR).
+* **A second concurrent operator becomes real.** `vocabulary.md#Operator`
+  defines operator as singular; this ADR inherits that. If multi-operator
+  becomes a use case, the document model's "replace on hand-off"
+  semantics produce write-conflicts (discovery Red Hotspot #9). Drives
+  reversal toward B2 or toward a locking protocol.
+* **Document model schema migration becomes painful.** Threshold:
+  changing the nine-field schema requires manual migration of
+  `STATE.md` files in active consumer repos. Drives evaluation of B2 as
+  the new baseline.
+* **Cross-BC reference resolution failure (`active_feature_run_id`
+  pointing at deleted/closed/reopened issue) becomes a real bug.**
+  Threshold: one confirmed resume failure attributable to a stale
+  `active_feature_run_id` reference (binary event; a single occurrence
+  is sufficient given that the failure mode is silent misdirection, not
+  a recoverable warning). When triggered, a follow-up ADR specifies the
+  resolution protocol. Discovery Red Hotspot #8.
+* **A third hand-off leg is proposed** beyond `STATE.md` + `session-log`
+  + `plan-lint.sh`. The Triple Hand-off Contract is binary today; a
+  fourth leg makes it Quadruple, and the contract's all-or-nothing
+  invariant must be re-stated.
+
+## Links
+
+* GitHub issue #128 — STATE.md + session-log + plan.md triple hand-off
+  contract problem statement.
+* `docs/decisions/0020-god-aggregate-sub-aggregate-extraction.md` — sub-
+  aggregate extraction precedent; this ADR applies the same
+  cross-aggregate communication pattern at cross-BC scope (sub-decision
+  3).
+* `docs/decisions/0021-adopt-nine-principle-hardened-revision.md` — Principle 9 hand-off contract ADR; this BC exists to materialise the continuity obligation Principle 9 mandates. Note: ADR-0021 is currently `proposed`, not `accepted`; the binding authority is `docs/principles.md#9` directly, which is in force regardless of ADR-0021's status.
+* `docs/principles.md#9-перехват--контракт` — Principle 9, the hand-off
+  contract this BC exists to satisfy.
+* `docs/principles.md#8-антихрупкость-по-домену-запас-2-3-не-1000` —
+  Principle 8, the basis for choosing document model over event-sourcing
+  (sub-decision 2).
+* `docs/principles.md#3-сначала-детерминированный-тулинг-потом-может-быть-агент` —
+  Principle 3, the basis for `plan-lint.sh` being bash/grep, not LLM.
+* `docs/principles.md#что-значит-архитектурно-значимо` — four
+  architectural-significance triggers, all four firing for this
+  decision.
+* `docs/domain/continuity-discovery.md` — `domain-researcher` discovery
+  output: 15 UL terms, BC Canvas, 10 Red Hotspots. This ADR resolves
+  Hotspots #1, #2, #3, #4, #5, #7; defers #6, #8, #9, #10.
+* `docs/domain/vocabulary.md` — current Ubiquitous Language; will be
+  extended at `/implement` per Confirmation item 2.
+* `docs/domain/overview.md` — `claude-mini-pipeline` BC overview; the
+  sibling whose boundary this ADR sets.
+* Repo-root `plan.md` — issue #128 plan; §4 records the chosen sub-
+  decisions enumerated here.
+* `bootstrap/agents/domain-reviewer.md` — load-bearing update site for
+  Confirmation item 9 (latent-protection extension).
+* `bootstrap/hooks/stop-hook.sh` — implementation site for Confirmation
+  item 7.

--- a/docs/domain/continuity-discovery.md
+++ b/docs/domain/continuity-discovery.md
@@ -1,0 +1,297 @@
+# Session Continuity — Domain Discovery
+
+**Status:** discovery draft (pre-implementation, issue #128)
+**Date:** 2026-05-03
+**Author:** `domain-researcher`
+**Scope:** propose a Ubiquitous Language extension and a Bounded Context Canvas sketch for a new "Session Continuity" bounded context. **Not** a vocabulary.md edit — that is for the operator to merge after review.
+**Relationship to `claude-mini-pipeline`:** sibling BC, not a sub-aggregate. Session Continuity *observes* `FeatureRun` (read-only reference via `active_feature_run_id`); it does not own pipeline orchestration. See "Boundary tensions" red hotspot below for the two unresolved seams.
+
+---
+
+## Why a new BC
+
+`claude-mini-pipeline` owns *one feature delivery* end-to-end (`FeatureRun` lifecycle: issue → plan → ADR → implement → review → PR → merge). It does not own *what happens between LLM sessions* — the moment the session ends and a new operator (or the same operator on a new day) tries to pick up where things stopped.
+
+Issue #128 introduces three artifacts whose collective purpose is "the next session can resume in ≤5 minutes":
+- `STATE.md` — snapshot (≤200 lines)
+- `session-log/YYYY/MM/YYYY-MM-DD.md` — append-only daily log
+- `plan.md` linter — verifies design-decision → ADR-ref discipline
+
+The first two clearly belong to a continuity-of-work concern that spans multiple `FeatureRun`s and multiple sessions. The third is borderline (see hotspot #1).
+
+A separate BC keeps `FeatureRun` invariants clean: `FeatureRun` already has 13 commands and a non-trivial state machine. Folding "session snapshot" attributes into it would re-create the God Aggregate problem ADR-0020 just solved.
+
+---
+
+## Ubiquitous Language extension (proposed additions)
+
+These entries are written in the style of `docs/domain/vocabulary.md` (alphabetical, one-sentence definition, discriminating note where confusion is likely). They are **proposed additions only** — `vocabulary.md` is not edited by this discovery doc.
+
+Existing terms (`FeatureRun`, `GovernanceRun`, `TwoVoiceReview`, `Operator`, `Main Loop`, `ADR`, etc.) are referenced but not redefined.
+
+**Intentional exclusions from the UL extension.** Three of the nine `STATE.md` fields are deliberately **not** added as Ubiquitous Language terms because they carry no discriminating semantic weight beyond their plain meaning: `date_iso` (ISO-8601 calendar date), `current_branch` (git branch name), `last_commit_sha` (git commit SHA). They are described in `STATE.md`'s field list and need no separate dictionary entry. The remaining six fields plus `STATE.md`, `session-log`, `Session`, and the conceptual umbrella terms (`Hand-off`, `Continuity`, `Resume`, `Human Resume Test`, `Triple Hand-off Contract`, `plan.md Linter`) are defined below.
+
+---
+
+### active_feature_run_id
+
+The one of the nine `STATE.md` fields holding a reference (issue number, e.g., `#128`) to the `FeatureRun` currently in progress, or `null` if no run is active. Read-only pointer across the BC boundary into `claude-mini-pipeline`; resolves to a `FeatureRun` aggregate that Session Continuity does not own.
+
+*Discriminating note:* this is a reference, not an embedded copy of `FeatureRun` state. Session Continuity reads `FeatureRun.dod_state` by ID at snapshot time; it does not mirror or cache it (ADR-0020 cross-aggregate communication pattern).
+
+---
+
+### blocked_on
+
+A `STATE.md` field naming the single concrete obstacle preventing forward progress, or `null` if not blocked. Phrased as a noun-phrase referencing a person, ticket, decision, or external system — not a free-form excuse ("waiting on operator decision re: ADR-0021", not "lots of stuff to think about").
+
+*Discriminating note:* `blocked_on` is operator-asserted at snapshot time; no agent infers it. Distinct from `risk_flags` — `blocked_on` is a hard stop right now; `risk_flags` are warnings about possible future stops.
+
+---
+
+### Continuity (property)
+
+The property that work-in-progress survives the boundary between LLM sessions: any next session can read `STATE.md` + the most recent `session-log` entry and resume meaningful work without interrogating the operator. Continuity is the goal; the Session Continuity BC owns the artifacts that maintain it.
+
+*Discriminating note:* continuity is not the same as persistence. Persistence is "data still exists on disk." Continuity is "a new session can act on that data without ramp-up."
+
+---
+
+### Hand-off (triple)
+
+The contract by which a session transfers state to its successor: `STATE.md` (snapshot, replaces) + `session-log/YYYY/MM/YYYY-MM-DD.md` (history, appends) + `plan.md` linter pass (decision discipline, gates). Called "triple" because all three artifacts must be in their valid post-hand-off state simultaneously for the hand-off to be considered complete.
+
+*Discriminating note:* a hand-off is not a commit. A commit changes the repo; a hand-off prepares for session change. They often coincide but are not the same — a session can hand off without committing (e.g., end-of-day with WIP), and a commit happens without hand-off (mid-session).
+
+---
+
+### Human Resume Test
+
+The acceptance criterion for Session Continuity: an operator (or a fresh agent) given only `STATE.md` and the latest `session-log` entry can identify the next concrete action and begin work within five minutes. The five-minute budget is a sustained design constraint, not a stopwatch metric per session.
+
+*Discriminating note:* the Human Resume Test is the BC's primary NFR, not a unit test. It is verified by periodic operator drill (rare) or by post-mortem after a real resume (common). It is not mechanically measured.
+
+---
+
+### next_3_actions
+
+A `STATE.md` field listing exactly three ordered, concrete next actions, written as imperatives (e.g., "Run /implement on plan.md §3"). Cardinality is fixed at three: fewer signals premature stop, more signals lack of focus.
+
+*Discriminating note:* `next_3_actions` describes the immediate plan, not the full backlog. The full backlog lives in GitHub issues; `next_3_actions` is the slice the next session executes first.
+
+---
+
+### open_questions
+
+A `STATE.md` field listing zero or more unresolved questions the current session encountered that the next session needs answers for before progressing. Each entry is one line, phrased as a question with enough context that a reader who was not present can understand what is being asked.
+
+*Discriminating note:* `open_questions` is **not** the same as `Red Hotspot`. `Red Hotspot` (defined in `vocabulary.md`) is a BC-level invariant tension surfaced in `overview.md#red-hotspots` and may persist for sprints. `open_questions` is per-session and short-lived — resolved within hours/days or escalated to a Red Hotspot or GitHub issue. Lifecycle, scope, and audience differ.
+
+---
+
+### plan.md Linter
+
+A check that scans the current `plan.md` and verifies every entry under §4 ("Selected approach") and §3 ("Approaches considered") that asserts a design decision carries an `ADR-ref` (`docs/decisions/NNNN-*.md` or explicit "no ADR — justification: ..."). Run as part of the hand-off contract; failure blocks the hand-off from being declared complete.
+
+*Discriminating note:* the plan.md linter enforces ADR-discipline on plan content, which is `claude-mini-pipeline` concern, but is invoked from the hand-off contract, which is Session Continuity concern. This BC owns the *invocation* (when to run); `claude-mini-pipeline` owns the *rule definition* (what counts as a design decision). See hotspot #1.
+
+---
+
+### Resume
+
+The act of a new session reading the hand-off artifacts and beginning meaningful work on the previous session's outstanding context. Distinct from "starting fresh" (no prior STATE.md) and from "continuing within a session" (no session boundary crossed).
+
+*Discriminating note:* a resume succeeds when the first action a new session takes matches one of the prior session's `next_3_actions` (or explicitly supersedes one with justification). A resume that re-plans from scratch is a continuity failure, not a successful resume.
+
+---
+
+### risk_flags
+
+A `STATE.md` field listing zero or more known risks the next session should be aware of: pending external dependencies, suspected bugs not yet investigated, drift between docs and code, etc. Each flag is one line; `risk_flags: []` is a valid (and common) state.
+
+*Discriminating note:* `risk_flags` are warnings, not blockers — work can proceed despite them. `blocked_on` is a single hard stop; `risk_flags` is a list of soft warnings.
+
+---
+
+### Session
+
+A continuous interval of LLM (Claude Code) operation under a single operator presence, bounded on each side by a session-end event (operator closes the client, advisor times out, machine sleeps, day rolls over). Identified by `session_id` in `STATE.md`. The unit of work that hand-offs occur between.
+
+*Discriminating note:* a session is not a `FeatureRun`. A single session may span zero, one, or several `FeatureRun`s; a single `FeatureRun` typically spans several sessions. They are orthogonal lifecycles.
+
+---
+
+### session-log
+
+The append-only daily log file at `session-log/YYYY/MM/YYYY-MM-DD.md` recording per-session entries: session boundaries, significant decisions, advisor calls, hand-off events. One file per UTC day; entries are appended chronologically and never edited or deleted.
+
+*Discriminating note:* session-log is not the same family as `docs/gate-audit/events.jsonl`. Both are append-only logs, but session-log is human-readable narrative for resume; `events.jsonl` is structured machine data for ROI analysis. They serve different consumers and are not unified by design (see hotspot #4).
+
+---
+
+### session_id
+
+A `STATE.md` field uniquely identifying the session that wrote the current snapshot. Format and generation rule are not yet decided (see hotspot #3) — candidates include UTC timestamp, ULID, or git-style short hash.
+
+*Discriminating note:* `session_id` identifies the *writer* of the snapshot, not the *FeatureRun*. The `active_feature_run_id` field is a separate reference into a different BC.
+
+---
+
+### STATE.md
+
+The repo-root snapshot file (≤200 lines) with nine fields recording the current resumable state of work: `session_id`, `date_iso`, `current_branch`, `last_commit_sha`, `active_feature_run_id`, `next_3_actions`, `blocked_on`, `open_questions`, `risk_flags`. Replaced (not appended) on each hand-off; the prior state moves to `session-log` history.
+
+*Discriminating note:* `STATE.md` is not a backlog and not a runbook. It is a thin snapshot whose only job is to satisfy the Human Resume Test. Anything that does not contribute to a five-minute resume should not be in STATE.md.
+
+---
+
+### Triple Hand-off Contract
+
+The combined precondition that all three hand-off artifacts (STATE.md updated and ≤200 lines; session-log entry appended for today; plan.md linter passing) are simultaneously valid. The contract is binary: all three pass, or hand-off is incomplete. Partial hand-offs are not a recognised state.
+
+*Discriminating note:* "triple" is normative, not descriptive. It enforces that snapshot-without-history (STATE.md changes but no log entry) and history-without-snapshot (log entry but stale STATE.md) are both equally broken. The plan.md linter being the third leg is the design choice currently most contested (see hotspot #1).
+
+---
+
+## Where these terms fit relative to existing aggregates
+
+| New term | Relationship to existing BC |
+|---|---|
+| `STATE.md` | New aggregate root candidate in Session Continuity BC; references `FeatureRun` by `active_feature_run_id` |
+| `session-log` | New entity in Session Continuity BC; append-only; not owned by any `FeatureRun` |
+| `Session` | New aggregate root candidate in Session Continuity BC; lifecycle orthogonal to `FeatureRun` |
+| `Hand-off` | New process/event concept in Session Continuity BC; triggers cross to `claude-mini-pipeline` only via plan.md linter |
+| `Continuity`, `Resume`, `Human Resume Test` | Properties / acceptance criteria of Session Continuity BC |
+| `next_3_actions`, `blocked_on`, `risk_flags`, `open_questions`, `session_id`, `active_feature_run_id` | Attributes of the `STATE.md` aggregate |
+| `plan.md Linter` | **Cross-BC seam** — owned by Session Continuity (invocation), enforces a `claude-mini-pipeline` rule (ADR-discipline). See hotspot #1 |
+
+`FeatureRun` is **not modified** by this BC. Session Continuity holds a reference (`active_feature_run_id`) and may read `FeatureRun.dod_state`, `FeatureRun.issue_ref` for snapshot content, but emits no commands into `claude-mini-pipeline`.
+
+Plain attributes `date_iso`, `current_branch`, `last_commit_sha` are STATE.md fields but are intentionally not promoted to UL terms (see "Intentional exclusions" note at top of UL section).
+
+---
+
+## Invariants and rules
+
+### STATE.md invariants
+
+- **Size cap:** ≤200 lines (mechanical — verifiable by `wc -l`).
+- **Field completeness:** all nine fields present; missing fields invalidate the snapshot. Empty values (`null`, `[]`) are valid; missing keys are not.
+- **Replacement, not append:** every hand-off rewrites STATE.md in full; prior content is preserved only via the corresponding session-log entry.
+- **`active_feature_run_id` is a reference:** if non-null, it must resolve to an existing GitHub issue. Session Continuity does not duplicate `FeatureRun` state.
+- **`next_3_actions` cardinality:** exactly 3 entries when work is active; `[]` only valid when `blocked_on != null` or work is fully done.
+
+### session-log invariants
+
+- **Append-only:** entries are added; existing entries are never edited or deleted. Mechanically enforceable by a pre-commit check (not yet designed).
+- **One file per UTC day:** `session-log/YYYY/MM/YYYY-MM-DD.md`. Day boundary is UTC, not local — operators in different timezones use the same calendar.
+- **Chronological within file:** newest entry at the bottom (or top — convention not yet decided; see hotspot #5).
+
+### Triple Hand-off Contract invariant
+
+- **All-or-nothing:** hand-off is complete iff (STATE.md valid) AND (session-log entry for today exists) AND (plan.md linter passes). No partial-hand-off state is recognised.
+
+### Human Resume Test invariant (NFR)
+
+- **Five-minute budget:** the design must support a fresh operator/agent reaching first concrete action within five minutes of opening STATE.md. Verified by periodic drill or post-resume retrospective; not mechanically measured per session.
+
+---
+
+## Bounded Context Canvas — Session Continuity (sketch)
+
+### Purpose
+
+Maintain a triple hand-off contract (STATE.md + session-log + plan.md linter) such that any new LLM session or operator can resume work within five minutes of reading the snapshot — the Human Resume Test.
+
+### Strategic classification
+
+- **Core / Supporting / Generic:** Supporting. Continuity is critical to operator trust but does not differentiate the pipeline; it serves the core (`claude-mini-pipeline`).
+- **Domain role:** observability + resumability layer over feature work.
+
+### Responsibilities
+
+- Maintain `STATE.md` as a current ≤200-line snapshot of resumable state.
+- Append a `session-log/YYYY/MM/YYYY-MM-DD.md` entry on every session boundary and significant in-session event (advisor call, hand-off, decision recorded).
+- Run the `plan.md` linter at hand-off time and block the hand-off if it fails.
+- Provide a verifiable Human Resume Test as the BC's primary acceptance criterion.
+
+### Not responsibilities (out of scope)
+
+- Owning or mutating `FeatureRun`, `GovernanceRun`, or `TwoVoiceReview` state — they remain in `claude-mini-pipeline`.
+- Defining what counts as a "design decision" in plan.md — that rule belongs to `claude-mini-pipeline` (the linter only enforces it).
+- Storing pipeline events or governance decisions — `events.jsonl` (gate-audit) and ADRs are separate audit trails.
+
+### Inbound events (consumed)
+
+| Event | Source BC | Reaction |
+|---|---|---|
+| `FeaturePipelineStarted` | claude-mini-pipeline | Update `STATE.md.active_feature_run_id` |
+| `DoDSatisfied` | claude-mini-pipeline | Update `STATE.md.next_3_actions` (likely "open PR" or move to next ticket); append session-log note |
+| `AdvisorReturned` | claude-mini-pipeline | Append session-log entry referencing critique |
+| `SessionStarted` (operator action) | self | Read prior STATE.md; append session-log start marker |
+| `HandoffRequested` (operator command) | self | Run plan.md linter; refresh STATE.md; append session-log; emit `HandoffPrepared` or `HandoffBlocked` |
+
+### Outbound events (emitted)
+
+| Event | Trigger | Consumer |
+|---|---|---|
+| `StateSnapshotted` | STATE.md replaced | Session Continuity (internal); operator-visible |
+| `SessionLogAppended` | new entry written to today's log | Session Continuity (internal) |
+| `HandoffPrepared` | triple contract satisfied | Operator (signal to end session safely) |
+| `HandoffBlocked` | one or more contract legs fail | Operator (must resolve before session-end) |
+| `PlanLintFailed` | linter detects design-decision without ADR-ref | Operator (must add ADR-ref or justification before hand-off) |
+
+### Collaborators
+
+- **`claude-mini-pipeline` (upstream):** Session Continuity reads `FeatureRun` state by reference; relationship pattern = **Customer/Supplier** (we are customer, pipeline is supplier of run state). Reference-only reads via `active_feature_run_id` follow the ADR-0020 cross-aggregate communication pattern. (House style note: existing `overview.md` reserves explicit ACL labelling for external systems like GitHub; for an internal upstream, plain Customer/Supplier with reference-only reads is closer to current convention. Operator may tighten this.)
+- **Operator:** the only actor that triggers `HandoffRequested` and `SessionStarted`. Also the sole human consumer of `STATE.md` content.
+- **Git / filesystem:** the durability layer. STATE.md and session-log live in the repo; their persistence is git's responsibility.
+- **`adversarial-critic` and `domain-reviewer` (potential future):** may consume hand-off artifacts to verify continuity quality. Not currently designed.
+
+### Ubiquity of language
+
+All terms in the "Ubiquitous Language extension" section above must be used consistently across `STATE.md`, `session-log` entries, runbooks, ADRs, and PR descriptions. Drift detected by `domain-reviewer`.
+
+### Distance from core
+
+One hop from `claude-mini-pipeline` (its primary collaborator). Two hops from GitHub (via pipeline). No direct integration with Anthropic API, Codex CLI, or external services.
+
+---
+
+## Red Hotspots (open questions)
+
+These are explicit unresolved questions, flagged honestly per `vocabulary.md#Red Hotspot` discipline.
+
+1. **plan.md linter ownership seam.** The linter enforces `claude-mini-pipeline`'s ADR-discipline rule but is invoked from Session Continuity's hand-off contract. Two defensible placements: (a) linter lives in pipeline BC, hand-off contract simply *consumes* its result; (b) linter lives in Session Continuity, pipeline owns only the rule definition. Issue #128 bundles all three artifacts under "triple hand-off"; domain-wise, leg three may belong elsewhere. Needs operator decision before implementation.
+
+2. **Is `Session` an aggregate root, or is `STATE.md` a projection of `Session`?** Two models:
+   - `STATE.md` is the aggregate root; `Session` is just an attribute (`session_id`).
+   - `Session` is the aggregate root; `STATE.md` is its current-state projection and `session-log` entries are its event stream.
+   The second model maps cleanly onto event-sourcing; the first is simpler. No decision yet.
+
+3. **`session_id` generation rule undefined.** Candidates: UTC timestamp (`2026-05-03T14:32:00Z`), ULID, short git-style hash, or operator-typed string. Each has trade-offs (sortability vs collision-resistance vs human-readability). Not decided.
+
+4. **Relationship between `session-log` and `events.jsonl` (gate-audit).** Both are append-only logs in the repo; both record events with timestamps. Are they the same family with different schemas, or genuinely separate? Current draft says "separate" (different consumers, different formats), but a unified event log is a defensible alternative. Not yet ADR-discussed.
+
+5. **Chronological order in session-log entries.** Newest-at-top (more journal-like, fast read) vs newest-at-bottom (true append, never re-renders the file). Append-only invariant slightly favours bottom; readability favours top. Not decided.
+
+6. **Session boundary detection.** A session ends when… the client closes? An hour of inactivity? A new operator types `/resume`? The definition affects when `HandoffRequested` should fire automatically vs require operator command. Currently assumed operator-explicit; auto-detection deferred.
+
+7. **What if `STATE.md` is never updated?** A session that crashes mid-work leaves stale STATE.md. The next session reads outdated `next_3_actions` and may take wrong action. Mitigation could be a freshness field (`last_updated`) compared to `last_commit_sha` — not yet designed.
+
+8. **Cross-BC reference resolution failure.** If `active_feature_run_id` points to an issue that has been closed/reopened/deleted, what should the new session see? Currently undefined. Likely: snapshot stays as-recorded; resume logic surfaces a "stale reference" warning.
+
+9. **Concurrent sessions.** What happens if two operators (or one operator with two clients) write `STATE.md` simultaneously? Not currently in scope (operator is singular per `vocabulary.md#Operator`), but worth flagging if multi-operator becomes real.
+
+10. **`open_questions` vs `Red Hotspot` escalation path.** Both record unresolved questions but at different scope and lifetime. The lifecycle by which a session-scope `open_questions` entry escalates to a BC-scope `Red Hotspot` (or to a GitHub issue) is not formally defined. Likely operator-judgement at retrospective time, but the discipline could drift.
+
+---
+
+## Hand-off to next stage
+
+This discovery doc is intended for:
+1. **Operator review** — confirm or revise the BC boundary call (sibling vs sub-aggregate of `claude-mini-pipeline`), resolve red hotspots #1 and #2, decide `session_id` rule.
+2. **`domain-reviewer`** — verify no vocabulary drift against existing `vocabulary.md`, check that proposed terms do not collide with existing terms (especially `open_questions` vs `Red Hotspot`), validate cross-aggregate reference pattern matches ADR-0020.
+3. **`/plan 128`** — once boundary is confirmed and term set is approved, plan can proceed knowing the language and aggregate placement.
+
+`vocabulary.md` and `overview.md` are **not** modified by this discovery. Merging the proposed terms into `vocabulary.md` and adding a sibling BC overview at `docs/domain/session-continuity/overview.md` is a separate operator-approved step.


### PR DESCRIPTION
## Summary

- Introduces ADR-0024: new **Session Continuity** bounded context (sibling to `claude-mini-pipeline`) per issue #128
- Locks 9 sub-decisions: BC placement, `STATE.md` as document-model aggregate root, cross-BC reference pattern (`active_feature_run_id`), `session_id` format, session-log entry order, `plan-lint.sh` scope, log format, log/events.jsonl separation, stale-detection level
- Includes `docs/domain/continuity-discovery.md` (domain-researcher pre-ADR artifact, 15 UL terms, BC Canvas, 10 Red Hotspots — 6 resolved by ADR)
- `@agent-adr-reviewer`: APPROVE (2 NITs resolved inline)

## Gate status

- [x] `adr-reviewer`: APPROVE
- [ ] Operator approval → merge → unblocks `/implement` for #128

## Implements

`docs/decisions/0024-session-continuity-bc-and-state-schema.md`

> **Note:** This PR does not close #128. Implementation PR (with `Closes #128`) follows after this merges.