### PR TITLE
fix(audit,session-continuity): post-merge review BLOCKs #129 #128

### DIFF
--- a/bootstrap/hooks/stop-hook.sh
+++ b/bootstrap/hooks/stop-hook.sh
@@ -76,7 +76,12 @@ update_handoff() {
     new_branch=$(git -C "$cwd" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
     new_sha=$(git -C "$cwd" rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
-    # Infer active_feature_run_id from trailing -NNN in branch name
+    # Infer active_feature_run_id from trailing -NNN in branch name.
+    # Convention: feat/slug-NNN → #NNN. Known limitation: a branch with
+    # multiple numeric segments (e.g. feat/fix-v2-for-123-and-456) extracts
+    # the last number, which may not be the intended issue. Operator can
+    # override by setting active_feature_run_id manually in STATE.md before
+    # the session ends — the preservation logic below will keep the manual value.
     new_frid="null"
     if echo "$new_branch" | grep -qE '[-/]([0-9]+)$'; then
         new_frid="#$(echo "$new_branch" | grep -oE '[0-9]+$')"

--- a/bootstrap/scripts/plan-lint.sh
+++ b/bootstrap/scripts/plan-lint.sh
@@ -40,12 +40,13 @@ FAILURES=0
 section_content=""
 in_section=0
 
+SECTION_RE='^## ([34]\.?[[:space:]]|Considered|Chosen)'
 while IFS= read -r line; do
-    if echo "$line" | grep -qiE '^## [34]\.?[[:space:]]'; then
+    if echo "$line" | grep -qiE "$SECTION_RE"; then
         in_section=1
         continue
     fi
-    if echo "$line" | grep -qE '^## [^34]'; then
+    if echo "$line" | grep -qE '^## ' && ! echo "$line" | grep -qiE "$SECTION_RE"; then
         in_section=0
     fi
     if [ "$in_section" -eq 1 ]; then

--- a/bootstrap/scripts/ticket-audit.sh
+++ b/bootstrap/scripts/ticket-audit.sh
@@ -49,11 +49,14 @@ if [[ "$ARG" =~ ^[0-9]+$ ]]; then
     if ! command -v gh >/dev/null 2>&1; then
         printf "ERROR: gh CLI not found\n" >&2; exit 1
     fi
-    if ! gh_json=$(gh issue view "$ARG" --json title,body,labels 2>&1); then
-        printf "ERROR: gh issue view %s failed:\n%s\n" "$ARG" "$gh_json" >&2; exit 1
+    gh_err=$(mktemp)
+    if ! gh_json=$(gh issue view "$ARG" --json title,body,labels 2>"$gh_err"); then
+        printf "ERROR: gh issue view %s failed:\n%s\n" "$ARG" "$(cat "$gh_err")" >&2
+        rm -f "$gh_err"; exit 1
     fi
-    TITLE=$(printf '%s' "$gh_json" | jq -r '.title')
-    BODY=$(printf '%s' "$gh_json" | jq -r '.body')
+    rm -f "$gh_err"
+    TITLE=$(printf '%s' "$gh_json" | jq -r '.title // ""')
+    BODY=$(printf '%s' "$gh_json" | jq -r '.body // ""')
     LABEL_COUNT=$(printf '%s' "$gh_json" | jq '.labels | length // 0')
 else
     # File mode: extract title from first # heading; labels are unavailable
@@ -133,7 +136,7 @@ if ! section_exists "Acceptance criteria"; then
     fail "acceptance-criteria" "## Acceptance criteria section missing"
 else
     ac_content=$(section_content "Acceptance criteria")
-    ac_count=$(printf '%s\n' "$ac_content" | grep -cE '^- \[ \]' || true)
+    ac_count=$(printf '%s\n' "$ac_content" | grep -cE '^[[:space:]]*- \[ \]' || true)
     if [ "${ac_count:-0}" -ge 3 ]; then
         pass "acceptance-criteria" "$ac_count item(s)"
     else


### PR DESCRIPTION
## Summary

Post-merge fixes from full three-voice review (Claude /review + Codex + adversarial-critic) that ran after #186 and #187 were merged.

## Fixes

### #129 `ticket-audit.sh` — Codex BLOCKs
- **gh stderr isolation**: `2>&1` was mixing stderr into JSON payload — any `gh` warning on success would corrupt the JSON and break `jq`. Now: stdout only to variable, stderr to `mktemp` shown only on failure.
- **jq null-safety**: `.title` and `.body` with `// ""` — prevents literal `"null"` string from passing CC-regex and priority checks when GitHub fields are JSON null.

### #128 `plan-lint.sh` — adversarial-critic BLOCK
- **Section extractor heading mismatch**: extractor matched only `## [34]` numeric headings, but checks 1/2 explicitly accepted `## Considered` / `## Chosen`. Valid plan.md files using keyword headings triggered false FAIL. Extractor now uses `SECTION_RE` covering both forms.

### #129 `ticket-audit.sh` — adversarial-critic SUGGEST
- **Indented AC items**: `grep -cE '^- \[ \]'` → `'^[[:space:]]*- \[ \]'` — GitHub renders indented checkboxes identically; they should count toward the ≥3 threshold.

### #128 `stop-hook.sh` — adversarial-critic SUGGEST
- **Branch inference comment**: documented known limitation (last numeric segment extracted; ambiguous branch names may produce wrong `active_feature_run_id`; operator can override via STATE.md).

## Review coverage
- Claude /review: these fixes written against its findings
- Codex: reviewed the #129 SC2059 fix and the gh-stderr/jq-null findings
- adversarial-critic: APPROVE on #129, BLOCK on #128 plan-lint fixed here

Closes #129