### PR TITLE
chore(security): MCP transport hardening + pin versions + ToolHive eval #137

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,19 @@ jobs:
       - name: Run install verification test harness
         run: bash bootstrap/scripts/test-install-verification.sh
 
+  mcp-config-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+      - name: Lint .mcp.json against ADR-0028 transport security policy
+        run: bash bootstrap/scripts/check-mcp-config.sh .mcp.json
+      - name: Run check-mcp-config unit tests
+        run: bash bootstrap/scripts/test-check-mcp-config.sh
+
   secret-scan:
     runs-on: ubuntu-latest
     steps:

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,30 @@
+{
+  "mcpServers": {
+    "serena": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/oraios/serena@v1.2.0",
+        "serena",
+        "start-mcp-server",
+        "--context",
+        "claude-code"
+      ]
+    },
+    "context7": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "@upstash/context7-mcp@2.2.4"
+      ]
+    },
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,13 +158,13 @@ echo "Exit: $?"  # 0 = OK, 1 = blocked
 
 Репо использует три MCP-сервера. MCP (Model Context Protocol) — открытый стандарт, поддерживается Goose, opencode, Cursor и другими клиентами.
 
-| Сервер | Назначение | Когда использовать |
-|---|---|---|
-| **Serena** | Семантическая навигация по коду: поиск символов, их references, структура файла | Вместо grep на больших файлах |
-| **GitHub** | Чтение и запись issues, PR, projects, actions | Для работы с бэклогом и PR |
-| **Context7** | Актуальная документация библиотек (не из training data) | Перед любой гипотезой об API библиотеки |
+| Сервер | Transport | Pinned version | Назначение | Когда использовать |
+|---|---|---|---|---|
+| **Serena** | stdio | `v1.2.0` | Семантическая навигация по коду: поиск символов, их references, структура файла | Вместо grep на больших файлах |
+| **GitHub** | HTTP (allowlisted) | GitHub API | Чтение и запись issues, PR, projects, actions | Для работы с бэклогом и PR |
+| **Context7** | stdio | `2.2.4` | Актуальная документация библиотек (не из training data) | Перед любой гипотезой об API библиотеки |
 
-Конфигурация серверов — в `~/.claude/settings.json` (Claude Code) или в аналогичном config-файле твоего инструмента.
+Конфигурация серверов — в `.mcp.json` (repo root, `--scope project`, committable). Транспортная политика: ADR-0028 (`docs/decisions/0028-mcp-transport-security.md`). CI lint: `bootstrap/scripts/check-mcp-config.sh`.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,7 @@ echo "Exit: $?"  # 0 = OK, 1 = blocked
 | Сервер | Transport | Pinned version | Назначение | Когда использовать |
 |---|---|---|---|---|
 | **Serena** | stdio | `v1.2.0` | Семантическая навигация по коду: поиск символов, их references, структура файла | Вместо grep на больших файлах |
-| **GitHub** | HTTP (allowlisted) | GitHub API | Чтение и запись issues, PR, projects, actions | Для работы с бэклогом и PR |
+| **GitHub** | HTTP (allowlisted) | — (stable API) | Чтение и запись issues, PR, projects, actions | Для работы с бэклогом и PR |
 | **Context7** | stdio | `2.2.4` | Актуальная документация библиотек (не из training data) | Перед любой гипотезой об API библиотеки |
 
 Конфигурация серверов — в `.mcp.json` (repo root, `--scope project`, committable). Транспортная политика: ADR-0028 (`docs/decisions/0028-mcp-transport-security.md`). CI lint: `bootstrap/scripts/check-mcp-config.sh`.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,24 @@ bootstrap/
 
 **Scripts (8):** `mini-preflight`, `mini-session`, `mini-bootstrap-project`, `mini-health`, `review-codex.sh`, `gate-audit-lib.sh` (event-write helper), `gate-audit-aggregate.sh` (weekly aggregation), `forge.sh` (gate-tag CLI).
 
+## MCP Servers
+
+Три сервера, подключаемых через `.mcp.json` (repo-tracked, `--scope project`):
+
+| Сервер | Transport | Pinned version | Назначение |
+|---|---|---|---|
+| `serena` | stdio | `v1.2.0` | Семантическая навигация по коду (find symbol, references) |
+| `context7` | stdio | `2.2.4` | Актуальная документация библиотек (не из training data) |
+| `github` | HTTP (allowlisted) | GitHub API | Issues, PR, projects, actions |
+
+**Транспортная политика (ADR-0028):** stdio — дефолт для локальных серверов; HTTP — только для эндпоинтов из явного allowlist (`api.githubcopilot.com/mcp/`). Нет unauthenticated local HTTP MCP. stdio-серверы пинированы по semver/git-tag — CI блокирует merge без `@<version>` pin. HTTP-серверы (GitHub) контролируются allowlist, а не версией (стабильный API-эндпоинт).
+
+**Примечание по `context7`:** `@upstash/context7-mcp` запускается как локальный npm-процесс (stdio). Он по-прежнему обращается к Upstash backend по HTTPS. stdio закрывает Claude↔local-process вектор; от Upstash изоляция не является целью.
+
+**Quarterly review:** `docs/runbooks/mcp-quarterly-review.md` — проверка CVE, pin staleness, allowlist status (Q: январь, апрель, июль, октябрь).
+
+**При добавлении нового HTTP сервера:** нужен ADR-0028 amendment. Новые stdio серверы — только добавить в `.mcp.json` с явным pin.
+
 ## AGENTS.md + CLAUDE.md — два файла, два читателя
 
 Репо поддерживает два конфигурационных файла одновременно:

--- a/README.md
+++ b/README.md
@@ -92,15 +92,15 @@ bootstrap/
 |---|---|---|---|
 | `serena` | stdio | `v1.2.0` | Семантическая навигация по коду (find symbol, references) |
 | `context7` | stdio | `2.2.4` | Актуальная документация библиотек (не из training data) |
-| `github` | HTTP (allowlisted) | GitHub API | Issues, PR, projects, actions |
+| `github` | HTTP (allowlisted) | — (stable API) | Issues, PR, projects, actions |
 
-**Транспортная политика (ADR-0028):** stdio — дефолт для локальных серверов; HTTP — только для эндпоинтов из явного allowlist (`api.githubcopilot.com/mcp/`). Нет unauthenticated local HTTP MCP. stdio-серверы пинированы по semver/git-tag — CI блокирует merge без `@<version>` pin. HTTP-серверы (GitHub) контролируются allowlist, а не версией (стабильный API-эндпоинт).
+**Транспортная политика ([ADR-0028](docs/decisions/0028-mcp-transport-security.md)):** stdio — дефолт для локальных серверов; HTTP — только для эндпоинтов из явного allowlist (`api.githubcopilot.com/mcp/`). Нет unauthenticated local HTTP MCP. stdio-серверы пинированы по semver/git-tag — CI блокирует merge без `@<version>` pin. HTTP-серверы (GitHub) контролируются allowlist, а не версией (стабильный API-эндпоинт).
 
 **Примечание по `context7`:** `@upstash/context7-mcp` запускается как локальный npm-процесс (stdio). Он по-прежнему обращается к Upstash backend по HTTPS. stdio закрывает Claude↔local-process вектор; от Upstash изоляция не является целью.
 
-**Quarterly review:** `docs/runbooks/mcp-quarterly-review.md` — проверка CVE, pin staleness, allowlist status (Q: январь, апрель, июль, октябрь).
+**Quarterly review:** [docs/runbooks/mcp-quarterly-review.md](docs/runbooks/mcp-quarterly-review.md) — CVE check, pin staleness, allowlist status (Q: январь, апрель, июль, октябрь).
 
-**При добавлении нового HTTP сервера:** нужен ADR-0028 amendment. Новые stdio серверы — только добавить в `.mcp.json` с явным pin.
+**При добавлении нового HTTP сервера:** нужен ADR-0028 amendment. Новые stdio серверы — добавить в `.mcp.json` с явным pin.
 
 ## AGENTS.md + CLAUDE.md — два файла, два читателя
 

--- a/STATE.md
+++ b/STATE.md
@@ -2,29 +2,31 @@
 <!-- Principle 9 hand-off artifact. Replaced (not appended) on each session end. -->
 <!-- Five-minute cold-start: read this + latest session-log entry, start in 5 min. (ADR-0024) -->
 
-session_id: 2026-05-06T10:00:00Z
+session_id: 2026-05-06T20:13:24Z
 date_iso: 2026-05-06
-current_branch: main
-last_commit_sha: PR #206 merged
-active_feature_run_id: null
+current_branch: feat/mcp-transport-hardening-137
+last_commit_sha: ca2e5f4
+active_feature_run_id: #137
 
 completed_this_session:
-  - "#135 merged (PR #206): DoD compliance table — prune honor-only norms, automate"
-  - "3 new CI jobs added: install-verification, secret-scan, pr-body-check"
-  - "4 P2 tickets created: #202 #203 #204 #205"
-  - "gate-audit weekly report now includes DoD compliance snapshot section"
-  - "Internal Compliance table corrected: enforcer column added, 4 norms upgraded"
+  - "ADR-0028 drafted, reviewed (APPROVE), merged as PR #207"
+  - "#137 implement in progress on feat/mcp-transport-hardening-137"
+  - ".mcp.json created with pinned serena@v1.2.0, context7@2.2.4, github allowlisted"
+  - "bootstrap/scripts/check-mcp-config.sh — linter (11 tests, ShellCheck clean)"
+  - "CI job mcp-config-lint added to .github/workflows/ci.yml"
+  - "docs/runbooks/mcp-quarterly-review.md created"
+  - "README.md + AGENTS.md updated with MCP policy section"
 
 next_3_actions:
-  - Pick next issue from backlog (run /backlog-review or check GitHub Issues)
-  - Consider #202-#205 (P2 DoD mechanization) for next sprint
-  - Run /project-health weekly report if not done this week
+  - Run /qa on feat/mcp-transport-hardening-137
+  - Run /review (prod-bound: security-reviewer + reliability-reviewer + adversarial-critic)
+  - Run /codex-review, then gh pr create Closes #137
 
 blocked_on: null
 
 open_questions: []
 
 risk_flags:
-  - pr-body-check fires on [opened, synchronize, reopened] but NOT on PR body edits — known gap, tracked in comment on #203; fix requires adding `edited` to pull_request trigger types
-  - secret-scan regex 20-char threshold excludes short API keys (e.g. 16-char tokens); acceptable for this pure-shell/markdown repo type
-  - mutation.yml is a reference implementation that skips all language blocks on claude-mini itself (no src/); first real signal comes from target pet-projects after --target install
+  - Context7 stdio smoke test pending — switch from HTTP-remote to stdio may change toolset/latency
+  - Plugin marketplace duplicates: serena/context7 may still have user-scope entries → run dedup step from mcp-quarterly-review.md before first session after merge
+  - Quarterly review is honor-only (no mechanical gate); follow-up ticket to be created after #137 merge

--- a/bootstrap/scripts/check-mcp-config.sh
+++ b/bootstrap/scripts/check-mcp-config.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# check-mcp-config.sh — lint .mcp.json against ADR-0028 transport security policy
+#
+# Policies (ADR-0028 docs/decisions/0028-mcp-transport-security.md):
+#   1. Version pinning: every stdio server must have an explicit @<version> or @<tag>
+#      in its command args. "latest" and "*" are rejected.
+#   2. Transport allowlist: every HTTP server URL must be in ALLOWED_HTTP_URLS.
+#   3. No unauthenticated local HTTP: no server may use http://localhost or
+#      http://127.0.0.1 without an Authorization header entry.
+#
+# Usage: bash bootstrap/scripts/check-mcp-config.sh [path/to/.mcp.json]
+#   Default: .mcp.json in the current directory (repo root).
+#
+# Exit codes:
+#   0 — all policies satisfied
+#   1 — one or more policy violations found
+#   2 — setup error (jq not installed, file missing/unparseable)
+
+set -uo pipefail
+
+# --- ALLOWLIST (source of truth — docs/runbooks/mcp-quarterly-review.md mirrors this) ---
+ALLOWED_HTTP_URLS=(
+  "https://api.githubcopilot.com/mcp/"
+)
+
+# --- Setup ---
+
+MCP_FILE="${1:-.mcp.json}"
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+NC=$'\033[0m'
+
+fail=0
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "${RED}ERROR${NC}: jq is required but not installed." >&2
+  exit 2
+fi
+
+if [ ! -f "$MCP_FILE" ]; then
+  echo "${RED}ERROR${NC}: $MCP_FILE not found." >&2
+  exit 2
+fi
+
+if ! jq empty "$MCP_FILE" 2>/dev/null; then
+  echo "${RED}ERROR${NC}: $MCP_FILE is not valid JSON." >&2
+  exit 2
+fi
+
+# --- Structural validation: mcpServers must be a present, non-null object ---
+
+mcp_type=$(jq -r 'if has("mcpServers") then (.mcpServers | type) else "missing" end' "$MCP_FILE")
+case "$mcp_type" in
+  object)  ;;  # valid
+  missing) echo "${RED}ERROR${NC}: $MCP_FILE: 'mcpServers' key is absent — not a valid MCP config." >&2; exit 2 ;;
+  null)    echo "${RED}ERROR${NC}: $MCP_FILE: 'mcpServers' is null — not a valid MCP config." >&2; exit 2 ;;
+  *)       echo "${RED}ERROR${NC}: $MCP_FILE: 'mcpServers' is of type '$mcp_type', expected object." >&2; exit 2 ;;
+esac
+
+# --- Policy 1 & 2 & 3: iterate over servers ---
+
+server_count=$(jq '.mcpServers | length' "$MCP_FILE")
+if [ "$server_count" -eq 0 ]; then
+  echo "No MCP servers configured (empty mcpServers object) — nothing to check."
+  exit 0
+fi
+
+while IFS= read -r name; do
+  transport=$(jq -r --arg n "$name" '.mcpServers[$n].type // "stdio"' "$MCP_FILE")
+
+  if [ "$transport" = "stdio" ]; then
+    # Collect all args into a single space-joined string for version scanning
+    args_str=$(jq -r --arg n "$name" \
+      '[ .mcpServers[$n].command // "",
+         (.mcpServers[$n].args // [])[] ] | join(" ")' \
+      "$MCP_FILE")
+
+    # Version-pin check: two-pass approach.
+    #
+    # Pass 1 — FAIL if any unpinned token exists (covers multi-package patterns
+    #   like "npx --package=a@1.0 --package=b@latest" where rightmost-match would
+    #   find a@1.0 and silently pass b@latest). Scans ALL @-tokens, not just rightmost.
+    #   Scoped package names like @scope/pkg are excluded (contain a slash; e.g.
+    #   @upstash/context7-mcp has a slash before the @<version> separator).
+    #   Note: version-shaped tokens in non-package arg positions (e.g. git URL fragments,
+    #   header values) could produce false negatives — not validated; document known scope.
+    #
+    # Pass 2 — FAIL if no semver/vtag pin found at all.
+    #
+    # Accepted forms: @1.2.3, @v1.2.0, @1.2.3-beta.1 (npm semver with pre-release)
+    # Rejected forms: @latest, @*, @abc1234 (commit SHAs — use git tags instead)
+
+    unpinned=$(echo "$args_str" | grep -oE '@(latest|\*)' | head -1)
+    if [ -n "$unpinned" ]; then
+      echo "${RED}FAIL${NC} [version-pin] '$name': unpinned token '$unpinned' found in args"
+      echo "       All packages in command+args must be pinned. 'latest' and '*' are rejected."
+      echo "       Fix: replace '$unpinned' with explicit semver, e.g. @1.2.3 or @v1.2.0"
+      echo "       See: docs/runbooks/mcp-quarterly-review.md, ADR-0028 policy 1"
+      fail=1
+    else
+      version_pin=$(echo "$args_str" | grep -oE '@v?[0-9]+\.[0-9]+(\.[0-9]+)?(-[a-zA-Z0-9.-]+)?' | tail -1)
+      if [ -z "$version_pin" ]; then
+        echo "${RED}FAIL${NC} [version-pin] '$name': no @<semver> or @v<tag> found in args: $args_str"
+        echo "       Fix: add version specifier, e.g. 'npx pkg@1.2.3' or 'uvx --from git+...@v1.2.0'"
+        echo "       Note: commit SHAs are not accepted — use a git tag. See ADR-0028 policy 1"
+        echo "       See: docs/runbooks/mcp-quarterly-review.md"
+        fail=1
+      else
+        echo "${GREEN}OK${NC}   [version-pin] '$name': $version_pin"
+      fi
+    fi
+
+  elif [ "$transport" = "http" ] || [ "$transport" = "sse" ]; then
+    url=$(jq -r --arg n "$name" '.mcpServers[$n].url // ""' "$MCP_FILE")
+
+    # Policy 3: reject unauthenticated local HTTP.
+    # Covers localhost, 127.0.0.1, and 0.0.0.0 (all documented in ADR-0028 §policy 3).
+    # IPv6 loopback [::1] is also covered (spirit of policy, even if not enumerated in ADR).
+    if echo "$url" | grep -qiE '^https?://(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(:[0-9]+)?/'; then
+      # Only Authorization header counts (ADR-0028 §policy 3 names this explicitly).
+      # env.MCP_AUTH is not an ADR-documented auth mechanism — excluded intentionally.
+      auth=$(jq -r --arg n "$name" \
+        '.mcpServers[$n].headers.Authorization // ""' \
+        "$MCP_FILE")
+      if [ -z "$auth" ]; then
+        echo "${RED}FAIL${NC} [local-http-auth] '$name': local HTTP endpoint '$url' has no Authorization header — unauthenticated local HTTP is forbidden (ADR-0028 policy 3)"
+        fail=1
+        continue
+      fi
+    fi
+
+    # Policy 2: URL must be in allowlist
+    allowed=0
+    for allowed_url in "${ALLOWED_HTTP_URLS[@]}"; do
+      if [ "$url" = "$allowed_url" ]; then
+        allowed=1
+        break
+      fi
+    done
+
+    if [ "$allowed" -eq 0 ]; then
+      echo "${RED}FAIL${NC} [http-allowlist] '$name': '$url' is not in the approved HTTP allowlist"
+      echo "       Allowlist (source of truth: ALLOWED_HTTP_URLS in bootstrap/scripts/check-mcp-config.sh):"
+      for u in "${ALLOWED_HTTP_URLS[@]}"; do echo "         $u"; done
+      echo "       To add a new endpoint: amend ADR-0028 and update ALLOWED_HTTP_URLS in this script"
+      echo "       See: docs/decisions/0028-mcp-transport-security.md, docs/runbooks/mcp-quarterly-review.md"
+      fail=1
+    else
+      echo "${GREEN}OK${NC}   [http-allowlist] '$name': $url"
+    fi
+
+  else
+    echo "${RED}FAIL${NC} [unknown-transport] '$name': unknown transport type '$transport'"
+    fail=1
+  fi
+
+done < <(jq -r '.mcpServers | keys[]' "$MCP_FILE")
+
+if [ "$fail" -eq 0 ]; then
+  echo "All MCP server policies satisfied."
+fi
+
+exit "$fail"

--- a/bootstrap/scripts/test-check-mcp-config.sh
+++ b/bootstrap/scripts/test-check-mcp-config.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# test-check-mcp-config.sh — unit tests for check-mcp-config.sh
+#
+# Tests each exit condition with a minimal fixture .mcp.json in a temp directory.
+# No external dependencies beyond bash and jq (same as the linter itself).
+#
+# Exit codes: 0 = all pass, 1 = one or more failures.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LINTER="$SCRIPT_DIR/check-mcp-config.sh"
+
+pass=0
+fail=0
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+_run() {
+  local desc="$1"
+  local fixture="$2"
+  local expect_exit="$3"
+
+  local file="$tmpdir/mcp-test-$$.json"
+  printf '%s' "$fixture" > "$file"
+
+  bash "$LINTER" "$file" >/dev/null 2>&1
+  local actual_exit=$?
+
+  if [ "$actual_exit" -eq "$expect_exit" ]; then
+    echo "PASS: $desc"
+    pass=$((pass + 1))
+  else
+    echo "FAIL: $desc (expected exit $expect_exit, got $actual_exit)"
+    fail=$((fail + 1))
+  fi
+}
+
+# --- Fixtures ---
+
+VALID_PINNED='{
+  "mcpServers": {
+    "serena": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["--from", "git+https://github.com/oraios/serena@v1.2.0", "serena", "start-mcp-server"]
+    }
+  }
+}'
+
+VALID_SCOPED_NPM='{
+  "mcpServers": {
+    "context7": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["@upstash/context7-mcp@2.2.4"]
+    }
+  }
+}'
+
+VALID_HTTP_ALLOWLISTED='{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": { "Authorization": "Bearer sometoken" }
+    }
+  }
+}'
+
+MISSING_PIN='{
+  "mcpServers": {
+    "bad-server": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["some-mcp-server"]
+    }
+  }
+}'
+
+LATEST_TAG='{
+  "mcpServers": {
+    "bad-server": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["some-mcp-server@latest"]
+    }
+  }
+}'
+
+STAR_TAG='{
+  "mcpServers": {
+    "bad-server": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["some-mcp-server@*"]
+    }
+  }
+}'
+
+SCOPED_NO_VERSION='{
+  "mcpServers": {
+    "bad-server": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["@upstash/context7-mcp"]
+    }
+  }
+}'
+
+UNALLOWED_HTTP='{
+  "mcpServers": {
+    "bad-server": {
+      "type": "http",
+      "url": "https://evil.example.com/mcp/",
+      "headers": { "Authorization": "Bearer sometoken" }
+    }
+  }
+}'
+
+LOCAL_HTTP_NO_AUTH='{
+  "mcpServers": {
+    "bad-server": {
+      "type": "http",
+      "url": "http://localhost:8080/mcp/"
+    }
+  }
+}'
+
+LOCAL_HTTP_WITH_AUTH='{
+  "mcpServers": {
+    "ok-local": {
+      "type": "http",
+      "url": "http://localhost:8080/mcp/",
+      "headers": { "Authorization": "Bearer somelocaltoken" }
+    }
+  }
+}'
+
+EMPTY='{
+  "mcpServers": {}
+}'
+
+# Multi-package bypass: one pinned package + one unpinned → must fail
+# (covers npx --package=a@1.0.0 --package=b@latest pattern)
+MULTI_PKG_BYPASS='{
+  "mcpServers": {
+    "bad-server": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["--package=@upstash/context7-mcp@2.2.4", "--package=evil-helper@latest", "context7-mcp"]
+    }
+  }
+}'
+
+# uvx --with bypass: pinned base + unpinned extra dep
+UVX_WITH_BYPASS='{
+  "mcpServers": {
+    "bad-server": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["--from", "git+https://github.com/oraios/serena@v1.2.0", "--with", "evil@latest", "serena"]
+    }
+  }
+}'
+
+# 0.0.0.0 local bind without auth — must fail (ADR-0028 policy 3)
+LOCAL_HTTP_0000_NO_AUTH='{
+  "mcpServers": {
+    "bad-server": {
+      "type": "http",
+      "url": "http://0.0.0.0:8080/mcp/"
+    }
+  }
+}'
+
+# Missing mcpServers key entirely — must exit 2 (setup error)
+MISSING_KEY='{"foo": "bar"}'
+
+# mcpServers is null — must exit 2
+NULL_SERVERS='{"mcpServers": null}'
+
+# --- Tests ---
+
+_run "valid pinned git-tag (serena-style)"       "$VALID_PINNED"         0
+_run "valid scoped npm package with version"     "$VALID_SCOPED_NPM"     0
+_run "valid HTTP allowlisted URL"                "$VALID_HTTP_ALLOWLISTED" 0
+_run "empty mcpServers — passes trivially"       "$EMPTY"                0
+_run "missing pin — no @ in args"                "$MISSING_PIN"          1
+_run "scoped npm package without version"        "$SCOPED_NO_VERSION"    1
+_run "latest tag rejected"                       "$LATEST_TAG"           1
+_run "star tag rejected"                         "$STAR_TAG"             1
+_run "HTTP URL not in allowlist"                 "$UNALLOWED_HTTP"       1
+_run "local HTTP without auth — rejected"        "$LOCAL_HTTP_NO_AUTH"   1
+_run "local HTTP with auth — allowlist check applies" "$LOCAL_HTTP_WITH_AUTH" 1
+_run "multi-pkg bypass: pinned+unpinned — rejected" "$MULTI_PKG_BYPASS"  1
+_run "uvx --with bypass: pinned+unpinned — rejected" "$UVX_WITH_BYPASS"  1
+_run "0.0.0.0 local bind without auth — rejected" "$LOCAL_HTTP_0000_NO_AUTH" 1
+_run "missing mcpServers key — setup error (exit 2)" "$MISSING_KEY"      2
+_run "null mcpServers — setup error (exit 2)"    "$NULL_SERVERS"         2
+
+echo ""
+echo "Results: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] && exit 0 || exit 1

--- a/docs/runbooks/mcp-quarterly-review.md
+++ b/docs/runbooks/mcp-quarterly-review.md
@@ -1,0 +1,121 @@
+# MCP Quarterly Security Review
+
+**Frequency:** Every Q — January, April, July, October.  
+**Policy source:** `docs/decisions/0028-mcp-transport-security.md`  
+**Allowlist source of truth:** `bootstrap/scripts/check-mcp-config.sh` (constant `ALLOWED_HTTP_URLS`). This runbook mirrors it for readability — at any discrepancy, the script is authoritative.
+
+---
+
+## Current allowlist
+
+| Server | Transport | Pinned version | URL / command |
+|---|---|---|---|
+| `serena` | stdio | `v1.2.0` | `uvx --from git+https://github.com/oraios/serena@v1.2.0` |
+| `context7` | stdio | `2.2.4` | `npx @upstash/context7-mcp@2.2.4` |
+| `github` | HTTP (allowlisted) | N/A | `https://api.githubcopilot.com/mcp/` |
+
+**Note on `context7`:** the stdio transport connects Claude Code to a local npm process. That process makes HTTPS calls to the Upstash backend (`mcp.context7.com`). stdio closes the Claude↔local-process unauthenticated-HTTP vector; it does NOT isolate from Upstash. This is by design — see ADR-0028 §"Принципиальная важная точность".
+
+---
+
+## Review checklist (run each Q)
+
+### Step 1 — Advisory database check
+
+For each pinned package, check for known CVEs:
+
+```bash
+# Serena — GitHub Advisory Database
+open "https://github.com/advisories?query=oraios%2Fserena"
+# or: gh api graphql -f query='{ securityAdvisories(first:5) { nodes { summary } } }'
+
+# Context7 npm package
+open "https://github.com/advisories?query=upstash%2Fcontext7-mcp"
+# or: install in a temp dir and audit:
+#   mkdir -p /tmp/ctx7-audit && cd /tmp/ctx7-audit && npm install @upstash/context7-mcp@2.2.4 && npm audit
+
+# GitHub Copilot MCP API — check GitHub Security Advisories
+open "https://github.com/advisories?query=github+copilot+mcp"
+```
+
+### Step 2 — CVE search for transport layer
+
+Search for new CVEs affecting the Anthropic MCP SDK or stdio transport:
+
+```bash
+# Search GitHub for new issues/advisories
+gh search issues "MCP SDK CVE" --repo modelcontextprotocol/python-sdk --state open | head -10
+gh search issues "stdio transport vulnerability" --repo modelcontextprotocol/python-sdk --state open | head -10
+```
+
+### Step 3 — Pin staleness check
+
+Verify current pins against latest releases:
+
+```bash
+# Serena latest release
+curl -s https://api.github.com/repos/oraios/serena/releases/latest \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])"
+
+# Context7 latest npm version
+npm view @upstash/context7-mcp version
+```
+
+If latest is significantly ahead of pinned: evaluate upgrade cost and CVE exposure. Update `.mcp.json` and re-run `bash bootstrap/scripts/check-mcp-config.sh`.
+
+### Step 4 — Allowlist endpoint status
+
+```bash
+# GitHub Copilot MCP API — check availability
+curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $GITHUB_PERSONAL_ACCESS_TOKEN" \
+  https://api.githubcopilot.com/mcp/
+# Expected: 200 or 401 (reachable). 000 = network failure.
+```
+
+Check GitHub changelog for any auth mechanism changes at `https://api.githubcopilot.com`.
+
+---
+
+## Plugin-marketplace deduplication
+
+When `.mcp.json` is first applied (or after any version pin update), confirm no plugin-marketplace duplicates remain. Claude Code deduplication only triggers when command/URL matches exactly — a pinned entry differs from an unpinned plugin entry, so both can load simultaneously:
+
+```bash
+# Check for duplicate entries per server
+claude mcp list | grep -E 'serena|context7|github'
+```
+
+If a server appears twice (once from plugin, once from `.mcp.json`):
+
+```bash
+# Remove the unpinned plugin-scope copy (keep the .mcp.json project-scope one)
+claude mcp remove serena --scope user 2>/dev/null || claude mcp remove serena --scope local
+claude mcp remove context7 --scope user 2>/dev/null || claude mcp remove context7 --scope local
+```
+
+After removal, restart Claude Code and verify `claude mcp list` shows each server once.
+
+## Output
+
+Record one of the following in the session log after completing all four steps:
+
+- `mcp-review Q<quarter> <year>: no findings` — all clear, no action needed
+- `mcp-review Q<quarter> <year>: upgrade pin to <server>@<version>` — open PR with `.mcp.json` update
+- `mcp-review Q<quarter> <year>: ADR-trigger — re-evaluate transport policy` — open ADR-0028 amendment
+
+---
+
+## Adding a new external HTTP MCP server
+
+HTTP servers outside `ALLOWED_HTTP_URLS` are rejected by CI. To add one:
+
+1. Open an ADR-0028 amendment in `docs/decisions/0028-mcp-transport-security.md`.
+2. Add the URL to `ALLOWED_HTTP_URLS` in `bootstrap/scripts/check-mcp-config.sh`.
+3. Update the allowlist table in this runbook.
+4. PR must have `Implements docs/decisions/0028-mcp-transport-security.md` in body.
+
+---
+
+## Missed reviews
+
+If the quarterly review is skipped two Q in a row: open a follow-up issue to evaluate mechanical enforcement (cron-generated issue, dashboard alert). Manual discipline is the current mechanism — see ADR-0028 Negative Consequences.


### PR DESCRIPTION
## Summary

- `.mcp.json` (project-scope, committable): serena `@v1.2.0` (stdio), context7 `@2.2.4` (stdio → switched from HTTP-remote), GitHub Copilot API (HTTP allowlisted)
- `bootstrap/scripts/check-mcp-config.sh`: mechanical lint gate (16 tests) — enforces 3 ADR-0028 policies: version pinning, HTTP allowlist, no unauthenticated local HTTP
- `.github/workflows/ci.yml`: new `mcp-config-lint` required job
- `docs/runbooks/mcp-quarterly-review.md`: quarterly CVE review procedure + plugin dedup step
- `README.md` + `AGENTS.md`: MCP policy section with HTTP/stdio pin semantics clarified

## ADR

Implements docs/decisions/0028-mcp-transport-security.md (merged PR #207)

## Review summary

**security-reviewer:** BLOCK (multi-pkg bypass `@latest` past rightmost-match) → fixed; WARNING (`0.0.0.0` not in regex) → fixed  
**reliability-reviewer:** BLOCK (`mcpServers` missing/null → silent exit 0) → fixed  
**adversarial-critic:** APPROVE (2 cosmetic fixes applied)  
**Codex:** BLOCK 1 disagreement (bash call already explicit); BLOCK 2 valid (README overclaimed HTTP version pin) → fixed

## QA

**Tests:** 16/16 pass (5 new fixtures added post-review: multi-pkg bypass, uvx --with bypass, 0.0.0.0, missing key, null key)  
**ShellCheck:** clean on both scripts  
**CI YAML:** valid

**Layer 1 gate note:** eslint/jscpd not installed (no JS files in PR; npm cache needs `sudo chown ~/.npm`). All applicable gates passed.

**Known gap (accepted):** Context7 stdio smoke test requires live Claude Code session — operator must perform manually after merge (documented in STATE.md risk_flags).

## Two-voice

Claude + Codex: agreed (one documented disagreement on BLOCK 1 — bash call already explicit)

Closes #137