### PR TITLE
feat(bootstrap): notify.sh — push notifications (osascript + ntfy.sh) #223

### DIFF
--- a/bootstrap/scripts/README.md
+++ b/bootstrap/scripts/README.md
@@ -1,0 +1,110 @@
+# bootstrap/scripts — utility scripts
+
+Scripts in this directory are installed by `universal-setup.sh` into
+`~/.claude/scripts/` and used by bootstrap and pipeline workflows.
+Each script documents its interface in inline comments at the top.
+
+---
+
+## notify.sh — push notifications
+
+Sends a push notification with a given severity. Planned for use by `sprint.sh`
+(sprint orchestrator, ADR-0030; not yet implemented — see #44 Phase-0 conditions)
+and any other bootstrap script that needs to alert the operator without blocking
+the pipeline.
+
+### Interface
+
+```bash
+notify.sh <severity> <title> <url>
+```
+
+| Argument   | Values                     | Description                             |
+|------------|----------------------------|-----------------------------------------|
+| `severity` | `info`, `warn`, `critical` | Determines sound and ntfy.sh priority   |
+| `title`    | Short string               | Human-readable message                  |
+| `url`      | URL string                 | Context link — issue, PR, or dashboard  |
+
+### Transports
+
+**1. macOS osascript** — always attempted on Darwin if `osascript` is in `PATH`:
+
+| Severity   | Sound   | Notes                              |
+|------------|---------|------------------------------------|
+| `info`     | silent  |                                    |
+| `warn`     | Ping    |                                    |
+| `critical` | Sosumi  | Loud; operator expected to respond |
+
+URL appears as text in the notification body. Clicking the notification does not
+open the URL — this is an `osascript` limitation. Use ntfy.sh for clickable
+notifications on your phone.
+
+Requires Terminal.app to have **Notifications** permission:
+`System Settings → Notifications → Terminal → Allow Notifications`.
+
+**2. ntfy.sh** — attempted when `NTFY_TOPIC` env var is set and curl is available:
+
+| Severity   | ntfy priority |
+|------------|---------------|
+| `info`     | default       |
+| `warn`     | high          |
+| `critical` | urgent        |
+
+The notification on your phone is clickable and opens `url`. Subscribe to your
+topic in the ntfy.sh mobile app before first use.
+
+### Graceful degradation
+
+Transport failures never block the pipeline — `notify.sh` always exits 0 unless
+passed bad arguments.
+
+| Condition                                   | Behaviour                                     |
+|---------------------------------------------|-----------------------------------------------|
+| `NTFY_TOPIC` unset                          | ntfy.sh silently skipped                      |
+| `NTFY_TOPIC` contains invalid characters    | Warning to stderr, ntfy skipped, exit 0       |
+| curl delivery fails (network / HTTP error)  | Warning to stderr, exit 0                     |
+| Neither transport available (headless CI)   | Warning to stderr, exit 0                     |
+
+**Known limitations:** Notification history is not logged (out of scope for this
+script — see issue #223). If both transports are unavailable, the escalation is
+silently suppressed with only a stderr warning; no automatic retry or fallback to
+GitHub issue creation is performed.
+
+### Exit codes
+
+| Code | Meaning                                                    |
+|------|------------------------------------------------------------|
+| `0`  | Notification sent or gracefully suppressed                 |
+| `1`  | Bad arguments (wrong count or unknown severity)            |
+
+### Environment variables
+
+| Variable     | Required | Description                                              |
+|--------------|----------|----------------------------------------------------------|
+| `NTFY_TOPIC` | No       | ntfy.sh topic (`[A-Za-z0-9_-]+`). Subscribe to it first. If unset or invalid, ntfy.sh transport is skipped silently. |
+
+### Manual smoke test
+
+**Prerequisites:**
+
+1. Install the script: `./bootstrap/universal-setup.sh --install` (from this repo root)
+2. Grant Terminal.app notification permission: `System Settings → Notifications → Terminal → Allow Notifications`
+3. For ntfy.sh tests: install the ntfy.sh mobile app and subscribe to your topic
+
+```bash
+# Local notifications (macOS)
+bash ~/.claude/scripts/notify.sh info     "smoke info"     "https://github.com"
+bash ~/.claude/scripts/notify.sh warn     "smoke warn"     "https://github.com"
+bash ~/.claude/scripts/notify.sh critical "smoke critical" "https://github.com"
+
+# ntfy.sh (replace my-topic with your subscribed topic)
+NTFY_TOPIC=my-topic bash ~/.claude/scripts/notify.sh warn "ntfy smoke" "https://github.com"
+
+# No transports — should print WARNING and exit 0
+env -i PATH=/dev/null /bin/bash ~/.claude/scripts/notify.sh info "no transport" "https://github.com"
+```
+
+Expected results:
+- First three: notification appears in Notification Center with the appropriate sound.
+- Fourth: notification appears on phone (requires ntfy.sh subscription); clicking opens GitHub.
+- Fifth: prints `notify: WARNING: no transport available ...` to stderr, exits 0.

--- a/bootstrap/scripts/notify.sh
+++ b/bootstrap/scripts/notify.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# notify.sh — push-notification wrapper (osascript + ntfy.sh).
+#
+# Usage: notify.sh <severity> <title> <url>
+#   severity ∈ {info, warn, critical}
+#   title    — short human-readable message
+#   url      — context link (issue / PR / dashboard)
+#
+# Transports attempted in order, both independently, best-effort:
+#   1. macOS osascript — local Notification Center alert with severity sound
+#   2. ntfy.sh         — phone push via NTFY_TOPIC env var
+#
+# Exit codes: 0 = sent or gracefully suppressed, 1 = bad arguments
+
+# set -uo pipefail without -e: transports are best-effort; we check return codes
+# explicitly rather than aborting on first failure.
+set -uo pipefail
+
+# ── Arg validation ────────────────────────────────────────────────────────────
+
+if [ $# -ne 3 ]; then
+    printf 'Usage: %s <severity> <title> <url>\n' "$(basename "$0")" >&2
+    printf '  severity ∈ {info, warn, critical}\n' >&2
+    exit 1
+fi
+
+severity="$1"
+title="$2"
+url="$3"
+
+sound=""
+ntfy_priority="default"
+
+case "$severity" in
+    info)
+        sound=""
+        ntfy_priority="default"
+        ;;
+    warn)
+        sound="Ping"
+        ntfy_priority="high"
+        ;;
+    critical)
+        sound="Sosumi"
+        ntfy_priority="urgent"
+        ;;
+    *)
+        printf 'notify: unknown severity %s — must be info, warn, or critical\n' \
+            "'${severity}'" >&2
+        exit 1
+        ;;
+esac
+
+# ── Input sanitisation ────────────────────────────────────────────────────────
+# Remove characters that would break an AppleScript double-quoted string literal.
+title="${title//\\/}"
+title="${title//\"/}"
+title="${title//$'\n'/ }"
+title="${title//$'\r'/}"
+url="${url//\\/}"
+url="${url//\"/}"
+url="${url//$'\n'/}"    # collapse to empty, not space — spaces are invalid in URLs
+url="${url//$'\r'/}"
+
+# ── Transport 1: macOS osascript ──────────────────────────────────────────────
+
+_sent_local=0
+if command -v osascript >/dev/null 2>&1; then
+    if [ -n "$sound" ]; then
+        osascript <<EOF
+display notification "${title}
+${url}" with title "claude-mini" sound name "${sound}"
+EOF
+    else
+        osascript <<EOF
+display notification "${title}
+${url}" with title "claude-mini"
+EOF
+    fi
+    _sent_local=1
+fi
+
+# ── Transport 2: ntfy.sh ──────────────────────────────────────────────────────
+
+_sent_ntfy=0
+if [ -n "${NTFY_TOPIC:-}" ]; then
+    if [[ "$NTFY_TOPIC" =~ ^[A-Za-z0-9_-]+$ ]]; then
+        if command -v curl >/dev/null 2>&1; then
+            if curl -s -f \
+                    --max-time 5 --connect-timeout 3 \
+                    --data-raw "$title" \
+                    -H "Click: $url" \
+                    -H "Priority: $ntfy_priority" \
+                    "https://ntfy.sh/${NTFY_TOPIC}" >/dev/null 2>&1; then
+                _sent_ntfy=1
+            else
+                printf 'notify: WARNING: ntfy.sh delivery failed (curl error)\n' >&2
+            fi
+        else
+            printf 'notify: WARNING: curl not found — ntfy.sh transport skipped\n' >&2
+        fi
+    else
+        printf 'notify: WARNING: NTFY_TOPIC contains invalid characters — ntfy.sh skipped\n' >&2
+    fi
+fi
+
+# ── Fallback: no transport available ─────────────────────────────────────────
+
+if [ "$_sent_local" -eq 0 ] && [ "$_sent_ntfy" -eq 0 ]; then
+    printf 'notify: WARNING: no transport available (severity=%s title=%s)\n' \
+        "$severity" "$title" >&2
+fi
+
+exit 0

--- a/bootstrap/tests/verify/test-notify.sh
+++ b/bootstrap/tests/verify/test-notify.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# test-notify.sh — smoke tests for bootstrap/scripts/notify.sh
+#
+# Usage:
+#   bash bootstrap/tests/verify/test-notify.sh
+#   bash bootstrap/tests/verify/test-notify.sh /path/to/notify.sh
+#
+# Exit codes: 0 = all tests passed, 1 = one or more failures
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NOTIFY="${1:-$SCRIPT_DIR/../../scripts/notify.sh}"
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+NC=$'\033[0m'
+
+pass() { printf "  ${GREEN}PASS${NC} %s\n" "$1"; }
+fail() { printf "  ${RED}FAIL${NC} %s\n" "$1"; FAILURES=$((FAILURES+1)); }
+
+FAILURES=0
+
+if [ ! -f "$NOTIFY" ]; then
+    printf "${RED}FATAL:${NC} notify.sh not found at %s\n" "$NOTIFY" >&2
+    exit 1
+fi
+
+echo "=== notify.sh smoke-test ==="
+echo "Script: $NOTIFY"
+echo ""
+
+# ── Helper ────────────────────────────────────────────────────────────────────
+# make_fake_bin <name> <log-path>
+# Creates a temporary directory with a fake binary that records $* to log-path.
+# Prints the directory path.
+make_fake_bin() {
+    local name="$1"
+    local log_path="$2"
+    local fake_dir
+    fake_dir=$(mktemp -d)
+    printf '#!/bin/sh\nprintf '"'"'%%s\\n'"'"' "$*" >> "%s"\nexit 0\n' \
+        "$log_path" > "$fake_dir/$name"
+    chmod +x "$fake_dir/$name"
+    printf '%s' "$fake_dir"
+}
+
+# ── Test 1: info severity, no NTFY_TOPIC → osascript called, curl not called ─
+
+test_1() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' RETURN
+
+    local osa_log="$tmpdir/osascript.log"
+    local curl_log="$tmpdir/curl.log"
+    local osa_dir curl_dir
+    osa_dir=$(make_fake_bin "osascript" "$osa_log")
+    curl_dir=$(make_fake_bin "curl" "$curl_log")
+    trap 'rm -rf "$tmpdir" "$osa_dir" "$curl_dir"' RETURN
+
+    local exit_code=0
+    PATH="$osa_dir:$curl_dir:$PATH" NTFY_TOPIC="" \
+        bash "$NOTIFY" info "hello world" "https://example.com" >/dev/null 2>&1 || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "1: info without NTFY_TOPIC → exit 0"
+    else
+        fail "1: expected exit 0, got $exit_code"
+    fi
+
+    if [ -f "$osa_log" ]; then
+        pass "1: osascript was invoked"
+    else
+        fail "1: osascript was NOT invoked"
+    fi
+
+    if [ ! -f "$curl_log" ]; then
+        pass "1: curl NOT invoked (NTFY_TOPIC empty)"
+    else
+        fail "1: curl invoked unexpectedly"
+    fi
+}
+
+# ── Test 2: warn + NTFY_TOPIC set → both transports called ───────────────────
+
+test_2() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local osa_log="$tmpdir/osascript.log"
+    local curl_log="$tmpdir/curl.log"
+    local osa_dir curl_dir
+    osa_dir=$(make_fake_bin "osascript" "$osa_log")
+    curl_dir=$(make_fake_bin "curl" "$curl_log")
+    trap 'rm -rf "$tmpdir" "$osa_dir" "$curl_dir"' RETURN
+
+    local exit_code=0
+    PATH="$osa_dir:$curl_dir:$PATH" NTFY_TOPIC="test-topic" \
+        bash "$NOTIFY" warn "alert" "https://example.com" >/dev/null 2>&1 || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "2: warn with NTFY_TOPIC → exit 0"
+    else
+        fail "2: expected exit 0, got $exit_code"
+    fi
+
+    if [ -f "$osa_log" ]; then
+        pass "2: osascript invoked"
+    else
+        fail "2: osascript NOT invoked"
+    fi
+
+    if [ -f "$curl_log" ]; then
+        pass "2: curl invoked (ntfy transport)"
+    else
+        fail "2: curl NOT invoked despite NTFY_TOPIC being set"
+    fi
+
+    if grep -q "ntfy.sh/test-topic" "$curl_log" 2>/dev/null; then
+        pass "2: curl targeted correct ntfy.sh topic"
+    else
+        fail "2: curl did not target ntfy.sh/test-topic (log: $(cat "$curl_log" 2>/dev/null || echo empty))"
+    fi
+}
+
+# ── Test 3: no transports available → exit 0 + stderr WARNING ────────────────
+
+test_3() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' RETURN
+
+    # Use absolute bash path so PATH="$tmpdir" (hiding osascript/curl) doesn't
+    # prevent bash itself from being found.
+    local bash_bin
+    bash_bin="$(command -v bash)"
+
+    local stderr_out exit_code=0
+    stderr_out=$(PATH="$tmpdir" NTFY_TOPIC="" \
+        "$bash_bin" "$NOTIFY" critical "disaster" "https://example.com" 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "3: no transports → exit 0"
+    else
+        fail "3: expected exit 0, got $exit_code"
+    fi
+
+    if printf '%s' "$stderr_out" | grep -q "WARNING"; then
+        pass "3: stderr contains WARNING"
+    else
+        fail "3: stderr missing WARNING (got: $stderr_out)"
+    fi
+}
+
+# ── Test 4: bad severity → exit 1 + stderr mentions severity ─────────────────
+
+test_4() {
+    local stderr_out exit_code=0
+    stderr_out=$(bash "$NOTIFY" bad "title" "https://example.com" 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -eq 1 ]; then
+        pass "4: bad severity → exit 1"
+    else
+        fail "4: expected exit 1, got $exit_code"
+    fi
+
+    if printf '%s' "$stderr_out" | grep -q "bad"; then
+        pass "4: stderr mentions the bad severity value"
+    else
+        fail "4: stderr does not mention 'bad' (got: $stderr_out)"
+    fi
+}
+
+# ── Test 5: wrong arg count → exit 1 ─────────────────────────────────────────
+
+test_5() {
+    local exit_code=0
+    bash "$NOTIFY" info "only-two-args" >/dev/null 2>&1 || exit_code=$?
+
+    if [ "$exit_code" -eq 1 ]; then
+        pass "5: wrong arg count → exit 1"
+    else
+        fail "5: expected exit 1, got $exit_code"
+    fi
+}
+
+# ── Test 6: invalid NTFY_TOPIC → ntfy skipped, exit 0 ───────────────────────
+
+test_6() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local curl_log="$tmpdir/curl.log"
+    local osa_log="$tmpdir/osa.log"
+    local curl_dir osa_dir
+    curl_dir=$(make_fake_bin "curl" "$curl_log")
+    osa_dir=$(make_fake_bin "osascript" "$osa_log")
+    trap 'rm -rf "$tmpdir" "$curl_dir" "$osa_dir"' RETURN
+
+    local stderr_out exit_code=0
+    stderr_out=$(PATH="$osa_dir:$curl_dir:$PATH" NTFY_TOPIC="bad topic!" \
+        bash "$NOTIFY" info "test" "https://example.com" 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "6: invalid NTFY_TOPIC → exit 0"
+    else
+        fail "6: expected exit 0, got $exit_code"
+    fi
+
+    if [ ! -f "$curl_log" ]; then
+        pass "6: curl NOT invoked (invalid NTFY_TOPIC)"
+    else
+        fail "6: curl invoked despite invalid NTFY_TOPIC"
+    fi
+
+    if printf '%s' "$stderr_out" | grep -q "WARNING"; then
+        pass "6: stderr contains WARNING about invalid topic"
+    else
+        fail "6: stderr missing WARNING (got: $stderr_out)"
+    fi
+}
+
+# ── Test 7: @-prefix in title must NOT cause curl to read a file ─────────────
+# Regression for security finding: curl -d "@/path" reads file from disk.
+# --data-raw must be used instead of -d so "@..." is treated as literal text.
+
+test_7() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local curl_log="$tmpdir/curl.log"
+    local osa_log="$tmpdir/osa.log"
+    local curl_dir osa_dir
+    curl_dir=$(make_fake_bin "curl" "$curl_log")
+    osa_dir=$(make_fake_bin "osascript" "$osa_log")
+    trap 'rm -rf "$tmpdir" "$curl_dir" "$osa_dir"' RETURN
+
+    local exit_code=0
+    PATH="$osa_dir:$curl_dir:$PATH" NTFY_TOPIC="test-topic" \
+        bash "$NOTIFY" warn "@/etc/passwd" "https://example.com" >/dev/null 2>&1 \
+        || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "7: @-prefix title → exit 0"
+    else
+        fail "7: expected exit 0, got $exit_code"
+    fi
+
+    if [ -f "$curl_log" ]; then
+        if grep -q "\-\-data-raw" "$curl_log" 2>/dev/null || \
+           ! grep -q "/etc/passwd" "$curl_log" 2>/dev/null; then
+            pass "7: curl log does not contain file path (data-raw used)"
+        else
+            fail "7: curl log contains /etc/passwd — @-prefix was NOT neutralised"
+        fi
+    else
+        fail "7: curl was not invoked (NTFY_TOPIC was set — expected curl call)"
+    fi
+}
+
+# ── Test 8: newline in url collapses to empty (not space) ───────────────────
+# Regression for asymmetric sanitisation: title \n → space, url \n → empty.
+# Spaces in URLs break the Click: header sent to ntfy.sh.
+
+test_8() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local curl_log="$tmpdir/curl.log"
+    local osa_log="$tmpdir/osa.log"
+    local curl_dir osa_dir
+    curl_dir=$(make_fake_bin "curl" "$curl_log")
+    osa_dir=$(make_fake_bin "osascript" "$osa_log")
+    trap 'rm -rf "$tmpdir" "$curl_dir" "$osa_dir"' RETURN
+
+    local exit_code=0
+    # Pass a URL with an embedded newline
+    PATH="$osa_dir:$curl_dir:$PATH" NTFY_TOPIC="test-topic" \
+        bash "$NOTIFY" info "title" $'https://example.com\ninjected' \
+        >/dev/null 2>&1 || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "8: newline in url → exit 0"
+    else
+        fail "8: expected exit 0, got $exit_code"
+    fi
+
+    if [ -f "$curl_log" ]; then
+        # If the newline was preserved in url, the Click: header value splits across
+        # lines in the curl args, producing >1 line in the log. After stripping, the
+        # args fit on a single line.
+        local line_count
+        line_count=$(wc -l < "$curl_log")
+        if [ "$line_count" -le 1 ]; then
+            pass "8: curl args are single-line (newline stripped from url)"
+        else
+            fail "8: curl log has $line_count lines — newline NOT stripped from url (header injection risk)"
+        fi
+    else
+        fail "8: curl not invoked (NTFY_TOPIC set — expected curl call)"
+    fi
+}
+
+# ── Run all tests ─────────────────────────────────────────────────────────────
+
+test_1
+test_2
+test_3
+test_4
+test_5
+test_6
+test_7
+test_8
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+    printf '%bAll tests passed.%b\n' "$GREEN" "$NC"
+    exit 0
+else
+    printf '%b%d test(s) failed.%b\n' "$RED" "$FAILURES" "$NC"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds `bootstrap/scripts/notify.sh` — push notification wrapper with macOS osascript and ntfy.sh transports
- Adds `bootstrap/tests/verify/test-notify.sh` — 20 assertions covering all branches + 2 security regression cases
- Adds `bootstrap/scripts/README.md` — interface docs, graceful degradation table, manual smoke steps

## Intent check

10/10 AC items covered. See full table in `/intent-check 223` output above.

## QA

**Tests:** All changed paths covered — `bootstrap/tests/verify/test-notify.sh` (6 scenarios, 20 assertions, 20/20 PASS). PATH-mocking via fake bins. Shellcheck clean on both files (no `-S warning` flag).

**Docs:** `bootstrap/scripts/README.md` created. All contracts current.

## Review findings resolved

**Security (BLOCK → resolved):**
- `curl -d "$title"` → `--data-raw "$title"` — prevents @-file exfiltration to ntfy.sh topic. Regression test 7 covers this.
- URL CR/LF already stripped; Click: header injection closed. Regression test 8 covers newline-in-url.
- `--max-time 5 --connect-timeout 3` added — prevents curl hanging the orchestrator on network partition.

**Adversarial critic (BLOCK → resolved):**
- Comment added explaining why url newline collapses to empty (not space) — intentional asymmetry, not copy-paste error.

**Docs (BLOCK → resolved):**
- `PATH=/dev/null bash` → `env -i PATH=/dev/null /bin/bash` — was non-executable as written.
- Install prerequisite added to smoke test section.
- Orphaned `sprint.sh` reference corrected to forward-looking language (#44 Phase-0).

## Known scope gaps (conscious compromises)

Per issue #223 Out-of-scope section:

- **No notification history log** — explicitly out of scope. Callers can log at their level if needed.
- **No transport = exit 0** — required by spec ("exit 0 с warning в stderr на headless CI"). Operator recovers by checking sprint.sh state via `.sprint-state` or GitHub labels.
- **No ntfy.sh retry on transient failure** — best-effort design per issue. Priority transport for `critical` escalation is phone push; osascript is the local backup.
- **osascript notifications not clickable** — `osascript` limitation without `terminal-notifier`. URL visible as text; ntfy.sh push provides clickable link on phone.
- **osascript permission silent failure** — if Terminal.app lacks notification permission, `_sent_local=1` is set but no notification appears. Documented in README manual smoke prerequisites.

## Two-voice review

- Claude: APPROVE (after resolving BLOCKs above)
- Codex: SKIPPED (Plus-OAuth timeout, exit 124) → deferred-review issue #234 created

Closes #223