### PR TITLE
chore(sprint): calibrate BUDGET_SPIKE_THRESHOLD after first sprint run

### DIFF
--- a/bootstrap/scripts/sprint.sh
+++ b/bootstrap/scripts/sprint.sh
@@ -15,7 +15,7 @@ set -uo pipefail
 CLAUDE_BIN="${CLAUDE_BIN:-claude}"
 GH_BIN="${GH_BIN:-gh}"
 REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}"
-BUDGET_SPIKE_THRESHOLD="${BUDGET_SPIKE_THRESHOLD:-50000}"
+BUDGET_SPIKE_THRESHOLD="${BUDGET_SPIKE_THRESHOLD:-600000}"
 CONSECUTIVE_FAILURE_THRESHOLD="${CONSECUTIVE_FAILURE_THRESHOLD:-3}"
 MAX_TURNS="${MAX_TURNS:-200}"
 NOTIFY_SH="$(cd "$(dirname "$0")" && pwd)/notify.sh"
@@ -98,10 +98,11 @@ check_state_integrity() {
 parse_usage() {
     local session_log="$1"
     local input_tokens output_tokens cache_read cache_write total
-    input_tokens=$(jq -r 'select(.type == "result") | .usage.input_tokens // 0' "$session_log" 2>/dev/null | tail -1)
-    output_tokens=$(jq -r 'select(.type == "result") | .usage.output_tokens // 0' "$session_log" 2>/dev/null | tail -1)
-    cache_read=$(jq -r 'select(.type == "result") | .usage.cache_read_input_tokens // 0' "$session_log" 2>/dev/null | tail -1)
-    cache_write=$(jq -r 'select(.type == "result") | .usage.cache_creation_input_tokens // 0' "$session_log" 2>/dev/null | tail -1)
+    # -R reads each line as raw string; try fromjson skips non-JSON lines (e.g. stderr text from 2>&1)
+    input_tokens=$(jq -Rr '(try fromjson // null) | select(. != null and .type == "result") | .usage.input_tokens // "0"' "$session_log" 2>/dev/null | tail -1)
+    output_tokens=$(jq -Rr '(try fromjson // null) | select(. != null and .type == "result") | .usage.output_tokens // "0"' "$session_log" 2>/dev/null | tail -1)
+    cache_read=$(jq -Rr '(try fromjson // null) | select(. != null and .type == "result") | .usage.cache_read_input_tokens // "0"' "$session_log" 2>/dev/null | tail -1)
+    cache_write=$(jq -Rr '(try fromjson // null) | select(. != null and .type == "result") | .usage.cache_creation_input_tokens // "0"' "$session_log" 2>/dev/null | tail -1)
     input_tokens="${input_tokens:-0}"
     output_tokens="${output_tokens:-0}"
     cache_read="${cache_read:-0}"
@@ -332,8 +333,10 @@ run_ticket() {
     state_set "$ticket_number" "running" ""
 
     local claude_exit=0
+    # --verbose required: stream-json emits usage events only in verbose mode
     "$CLAUDE_BIN" -p "/feature ${ticket_number}" \
         --output-format stream-json \
+        --verbose \
         --max-turns "${MAX_TURNS}" \
         > "$session_log" 2>&1 || claude_exit=$?
 
@@ -377,7 +380,7 @@ run_ticket() {
     fi
 
     # T5: budget_spike (warn, non-terminal)
-    if [ "${tokens_used:-0}" -gt "${BUDGET_SPIKE_THRESHOLD:-50000}" ]; then
+    if [ "${tokens_used:-0}" -gt "${BUDGET_SPIKE_THRESHOLD:-600000}" ]; then
         notify "$ticket_number" "budget_spike" "${tokens_used} tokens"
     fi
 

--- a/docs/architecture/sprint-orchestrator.md
+++ b/docs/architecture/sprint-orchestrator.md
@@ -156,7 +156,7 @@ stateDiagram-v2
 | T2 | `no_pr_after_session` | **critical** | сессия завершилась, PR не создан (нет open/merged PR с `Closes #N`) |
 | T3 | `issue_not_closed` | **warn** | PR смержен, но issue всё ещё открыт (`Closes #N` отсутствует в PR body) |
 | T4 | `governance_block` | **warn** | stdout сессии содержит `governance hook blocked` или `commit rejected`; handled by `notify()` — non-terminal |
-| T5 | `budget_spike` | **warn** | токены одного тикета > `$BUDGET_SPIKE_THRESHOLD` (default: 50 000); handled by `notify()` — non-terminal |
+| T5 | `budget_spike` | **warn** | токены одного тикета > `$BUDGET_SPIKE_THRESHOLD` (default: 600 000); handled by `notify()` — non-terminal |
 | T6 | `consecutive_failures` | **critical** | ≥3 тикетов подряд в состоянии `failed`, `escalated`, или `escalation_failed`; abort sweep, без label/comment |
 | T7 | `pre_existing_needs_human` | **warn** | label `needs-human` уже висит на тикете до старта сессии |
 | T8 | `no_commits_in_session` | **critical** | сессия `/feature` завершилась, в ветке нет новых коммитов и нет PR; **(deferred: TODO(#44), currently subsumed by T2)** |
@@ -189,20 +189,44 @@ Claude Code CLI с флагом `--output-format stream-json` выводит с�
 parse_usage() {
     local session_log="$1"
     local input_tokens output_tokens cache_read cache_write total
-    input_tokens=$(jq -r 'select(.type == "result") | .usage.input_tokens // 0' "$session_log" | tail -1)
-    output_tokens=$(jq -r 'select(.type == "result") | .usage.output_tokens // 0' "$session_log" | tail -1)
-    cache_read=$(jq -r 'select(.type == "result") | .usage.cache_read_input_tokens // 0' "$session_log" | tail -1)
-    cache_write=$(jq -r 'select(.type == "result") | .usage.cache_creation_input_tokens // 0' "$session_log" | tail -1)
+    # -R reads each line as raw string; try fromjson skips non-JSON lines (e.g. stderr text from 2>&1)
+    input_tokens=$(jq -Rr '(try fromjson // null) | select(. != null and .type == "result") | .usage.input_tokens // "0"' "$session_log" | tail -1)
+    output_tokens=$(jq -Rr '(try fromjson // null) | select(. != null and .type == "result") | .usage.output_tokens // "0"' "$session_log" | tail -1)
+    cache_read=$(jq -Rr '(try fromjson // null) | select(. != null and .type == "result") | .usage.cache_read_input_tokens // "0"' "$session_log" | tail -1)
+    cache_write=$(jq -Rr '(try fromjson // null) | select(. != null and .type == "result") | .usage.cache_creation_input_tokens // "0"' "$session_log" | tail -1)
     total=$((input_tokens + output_tokens + cache_read + cache_write))
     printf '%d' "$total"
 }
 ```
 
-Лог сессии пишется перенаправлением: `claude -p ... --output-format stream-json > "$session_log" 2>&1`.
+Лог сессии пишется перенаправлением: `claude -p ... --output-format stream-json --verbose > "$session_log" 2>&1`.
 
 Хрупкость: shape `usage` зафиксирован на момент написания ADR-0030. Если Anthropic меняет schema — парсинг сломается (Negative Consequence в ADR-0030). Validation: при парсинге ≤0 токенов — логировать `WARN: usage parse returned 0, schema may have changed`.
 
 **T10 `usage_limit` (отложен — трекинг: #240):** точное поле JSON output при rate-limiting неизвестно до первого прогона с Pro-подпиской. После прогона: найти поле в `$session_log` (`jq 'path(..)|join(".")' | grep -i "limit\|reset\|quota"`), добавить T10 в §B.4 trigger table и в ADR-0030 (список закрытый — требует Re-visit Trigger per §B.4).
+
+### Empirical baseline — calibration after first sprint (issue #228)
+
+После первого реального прогона (`sprint.sh --ticket 228`, 2026-05-11) накоплена одна измеренная точка:
+
+| Метрика | Значение |
+|---------|----------|
+| `input_tokens` | 14 |
+| `output_tokens` | 3 305 |
+| `cache_read_input_tokens` | 353 074 |
+| `cache_creation_input_tokens` | 37 652 |
+| **total (sum)** | **394 045** |
+
+**Формула для ревизии threshold:**
+```
+new_threshold = среднее(tokens_used по закрытым тикетам) × 1.5
+```
+
+Применение к N=1: 394 045 × 1.5 = 591 068 ≈ **600 000** (округление до 100K).
+
+**Ограничение N=1:** Тикет #228 — meta/chore с высоким cache_read (90% total). Значение нестабильно при других типах тикетов. Threshold 600 000 является предварительным (авторизовано issue #228). Ревизия — после накопления N ≥ 3–5 тикетов (трекинг: #244).
+
+**Multiplier 1.5 сохранён:** σ при N=1 неопределима. Изменение multiplier до 2.0 без данных о разбросе — нарушение Принципа 1 (размытость без обоснования).
 
 ---
 
@@ -367,8 +391,9 @@ run_ticket() {
     local claude_exit=0
     "$CLAUDE_BIN" -p "/feature ${ticket_number}" \
         --output-format stream-json \
-        > "$session_log" 2>&1
-    claude_exit=$?
+        --verbose \
+        --max-turns "${MAX_TURNS}" \
+        > "$session_log" 2>&1 || claude_exit=$?
 
     if [ "$claude_exit" -ne 0 ]; then
         echo "[TICKET #${ticket_number}] T1 process_error: claude exited ${claude_exit}" >&2
@@ -403,7 +428,7 @@ run_ticket() {
 
     # T5: budget_spike (warn, non-terminal) — token usage exceeded per-ticket threshold.
     # Uses notify(): the ticket may still have a merged PR; verify_outcome writes final state.
-    if [ "${tokens_used:-0}" -gt "${BUDGET_SPIKE_THRESHOLD:-50000}" ]; then
+    if [ "${tokens_used:-0}" -gt "${BUDGET_SPIKE_THRESHOLD:-600000}" ]; then
         notify "$ticket_number" "budget_spike" "${tokens_used} tokens"
     fi
 


### PR DESCRIPTION
## Summary

- Raises `BUDGET_SPIKE_THRESHOLD` default from 50 000 → 600 000 (empirical: 394 045 tokens observed × 1.5 = 591 K, rounded to 600 K)
- Bundles `--verbose` fix required for `--output-format stream-json` to emit usage events
- Hardens `parse_usage` with `jq -Rr/try fromjson` to skip non-JSON lines (stderr-in-log robustness)
- Updates §B.5 design doc: stale `run_ticket`/`parse_usage` snippets synced, new Empirical baseline subsection added

## QA

No test harness for `bootstrap/scripts/sprint.sh` (escape hatch applied; full mock-gh harness deferred TODO(#44)).

Manual acceptance checks:
- ✅ `BUDGET_SPIKE_THRESHOLD:-600000` — found in sprint.sh (lines 18 + 381)
- ✅ `600 000` — found in sprint-orchestrator.md §B.4 T5 row
- ✅ Formula `1.5`/`среднее` — found in §B.5 Empirical baseline
- ✅ `bash -n bootstrap/scripts/sprint.sh` — syntax OK
- ✅ No `50000` residue in changed files
- ✅ Issue #228 comment posted with decision rationale
- ✅ Follow-up issue #244 created for N≥3 revisit

## Intent check

| AC item | Status |
|---|---|
| Per-ticket usage агрегирован из `.sprint-logs/` | covered |
| Среднее и σ по 4 измерениям вычислены | covered (N=1, σ=N/A documented) |
| Решение по дефолту зафиксировано | covered (600K, issue comment + §B.5) |
| Решение по multiplier зафиксировано | covered (1.5 unchanged, rationale documented) |
| sprint.sh обновлён | covered |
| sprint-orchestrator.md §B.5 обновлён | covered |
| Решения в комментарии issue | covered (#4417896183) |

## Review gates

- Layer 1: PASSED
- security-reviewer: APPROVE
- reliability-reviewer: APPROVE (2 BLOCKs resolved: stale doc snippet + missing issue refs)
- adversarial-critic: APPROVE
- Codex: BLOCK resolved (parse_usage robustness — `jq -Rr/try fromjson` skips non-JSON lines)
- Two-voice: agreed

## Notes

- `BUDGET_SPIKE_THRESHOLD` is env-var overridable: `BUDGET_SPIKE_THRESHOLD=500000 ./sprint.sh`
- N=1 limitation documented in §B.5 and issue comment; threshold is preliminary
- Follow-up: #244 — revise after N≥3 ticket measurements

Closes #228
Implements docs/architecture/sprint-orchestrator.md §B.5