### PR TITLE
chore(sprint): freeze sprint orchestrator until digest-driven need

### DIFF
--- a/docs/architecture/sprint-orchestrator.md
+++ b/docs/architecture/sprint-orchestrator.md
@@ -2,7 +2,7 @@
 
 > **Implements:** [`docs/decisions/0030-sprint-orchestrator.md`](../decisions/0030-sprint-orchestrator.md)
 > **Related:** [`docs/runbooks/feature-pipeline.md`](../runbooks/feature-pipeline.md) · [`docs/runbooks/sprint.md`](../runbooks/sprint.md)
-> **Status:** design-ready; implementation pending (see #44 Phase-0 conditions)
+> **Status:** frozen 2026-06-10 — implemented (`sprint.sh`), but parked until digest-driven need; spike #227 closed as parked, bug #243 open (#255)
 
 Этот документ — рабочая спецификация для разработчика `bootstrap/scripts/sprint.sh`. ADR-0030 фиксирует «что и почему»; этот файл фиксирует «как именно». При расхождении — ADR-0030 имеет приоритет.
 

--- a/docs/decisions/0030-sprint-orchestrator.md
+++ b/docs/decisions/0030-sprint-orchestrator.md
@@ -1,6 +1,6 @@
 # 0030. Use external bash process as sprint orchestrator over `/feature`
 
-* Status: proposed
+* Status: proposed (frozen 2026-06-10 — parked until digest-driven need; spike #227 closed as parked, see #255)
 * Superseded-by: ~
 * Date: 2026-05-10
 * Deciders: Venil (operator)

--- a/docs/runbooks/sprint.md
+++ b/docs/runbooks/sprint.md
@@ -1,5 +1,7 @@
 # Runbook: Sprint Sweep
 
+> ⚠️ **СТАТУС: ЗАМОРОЖЕН (2026-06-10).** Оркестратор экспериментальный: spike #227 не завершён, известный баг #243 открыт, production-прогонов не было. Разморозка — по реальному трению в digest-проекте, не по календарю (решение оператора, #255). Код не удаляется; runbook остаётся справочным.
+
 > **ADR:** [`docs/decisions/0030-sprint-orchestrator.md`](../decisions/0030-sprint-orchestrator.md)
 > **Design doc:** [`docs/architecture/sprint-orchestrator.md`](../architecture/sprint-orchestrator.md)
 > **Script:** `bootstrap/scripts/sprint.sh`


### PR DESCRIPTION
Closes #255

## Решение оператора (2026-06-10)
Sprint-оркестратор замораживается до реального трения в digest-проекте. Основание: spike #227 не завершён, баг #243 (/feature не автономен в -p) открыт, production-прогонов за месяц не было; по pull-принципу инструмент дорабатывается от потребности, не от календаря.

## Что сделано
- ADR-0030: append-only пометка в Status (остаётся `proposed` — решение о принятии откладывается вместе с разморозкой)
- `docs/runbooks/sprint.md`: баннер ЗАМОРОЖЕН с условием разморозки
- `docs/architecture/sprint-orchestrator.md`: Status-строка актуализирована (была «implementation pending» при уже написанном sprint.sh)
- Код `sprint.sh` не тронут и не удалён
- Issues: #227 закрыт как parked; #243, #240, #244, #238 — label `blocked` + комментарий (parked batch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)