### PR TITLE
refactor(hooks): extract shared governance rules into governance-rules-lib.sh

### DIFF
--- a/bootstrap/hooks/commit-msg-governance.sh
+++ b/bootstrap/hooks/commit-msg-governance.sh
@@ -15,9 +15,10 @@
 # is root on their own machine; terminal commits to main remain ungoverned
 # by design. See ADR-0011 §Decision Outcome.
 #
-# Sync note: rules are duplicated from pre-commit-governance.sh (PreToolUse).
-# If the policy changes in one, update both.
-# Cross-reference: bootstrap/hooks/pre-commit-governance.sh
+# Rules 1-3 logic lives in governance-rules-lib.sh (shared with
+# pre-commit-governance.sh). The installer deploys the lib next to this hook
+# in every location (--install stages it to ~/.claude/git-hooks/,
+# --hook-this-repo copies it into .git/hooks/).
 
 set -uo pipefail
 
@@ -29,6 +30,15 @@ deny() {
 log() {
     echo "[commit-msg-governance] $*" >&2
 }
+
+# --- Shared rules library (fail-closed: governance without rules is no governance) ---
+
+_RULES_LIB="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/governance-rules-lib.sh"
+if [ ! -f "$_RULES_LIB" ]; then
+    deny "governance-rules-lib.sh not found next to the hook ($_RULES_LIB). From your claude-mini clone run: ./bootstrap/universal-setup.sh --install, then --hook-this-repo in this repo"
+fi
+# shellcheck source=/dev/null
+source "$_RULES_LIB"
 
 # --- Read commit message from file ($1 is the path) ---
 
@@ -64,73 +74,22 @@ if echo "$msg_subject" | grep -qE '^(fixup|squash)!'; then
     exit 0
 fi
 
-# --- Rule 1: Conventional Commits prefix (subject line only) ---
-
-cc_regex='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|adr)(\([a-z0-9_.-]+\))?!?:[[:space:]].+'
-
-if ! echo "$msg_subject" | grep -qE "$cc_regex"; then
-    deny "Rule 1: message does not follow Conventional Commits. Expected: type(scope?)!?: subject. Allowed types: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|adr. Got: '$msg_subject'"
-fi
-
-# --- Rule 2: Issue reference (full message body + branch name) ---
-# Refs may appear in subject OR body (e.g. "Closes #9" in a multi-line message).
+# --- Rules 1-3 (shared logic: governance-rules-lib.sh) ---
+# Rule 2/3 refs may appear in subject OR body (e.g. "Closes #9", "Implements ADR-0011").
 
 branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-
-has_issue_ref=false
-if echo "$msg_body" | grep -qE '#[0-9]+'; then
-    has_issue_ref=true
-fi
-if echo "$branch" | grep -qE '[0-9]+'; then
-    has_issue_ref=true
-fi
-
-# ADR-commits and bootstrap/initial commits are exempt from issue-ref requirement
-if ! echo "$msg_subject" | grep -qE '^adr(\(|:)' && ! echo "$msg_body" | grep -qE '\b(bootstrap|initial)\b'; then
-    if [ "$has_issue_ref" = "false" ]; then
-        deny "Rule 2: message or branch name must reference an issue (#NNN). Got subject: '$msg_subject', branch: '$branch'"
-    fi
-fi
-
-# --- Rule 3: ADR reference for decision-type staged changes (full message body) ---
-# Refs may appear in subject OR body (e.g. "Implements ADR-0011" in body).
-
 staged=$(git diff --cached --name-only 2>/dev/null || echo "")
 
-decision_markers=(
-    "docs/decisions/"
-    "go.mod"
-    "pyproject.toml"
-    "Cargo.toml"
-    "package.json"
-    ".github/workflows/"
-    "docs/domain/"
-)
-
-is_decision_change=false
-for marker in "${decision_markers[@]}"; do
-    if echo "$staged" | grep -qF "$marker"; then
-        is_decision_change=true
-        break
-    fi
-done
-
-# ADR-commits are self-referencing — exempt from the ADR-ref requirement
-if echo "$msg_subject" | grep -qE '^adr(\(|:)'; then
-    is_decision_change=false
+if ! gov_rule1_conventional_commits "$msg_subject"; then
+    deny "$GOV_REASON"
 fi
 
-if [ "$is_decision_change" = "true" ]; then
-    has_adr_ref=false
-    if echo "$msg_body" | grep -qiE 'adr[ -]?[0-9]+|docs/decisions/[0-9]+'; then
-        has_adr_ref=true
-    fi
-    if echo "$staged" | grep -qE '^docs/decisions/[0-9]+-.*\.md$'; then
-        has_adr_ref=true
-    fi
-    if [ "$has_adr_ref" = "false" ]; then
-        deny "Rule 3: decision-type change detected (staged: $(echo "$staged" | tr '\n' ' ' | head -c 200)). Commit must reference an ADR (e.g., 'Implements ADR-0012' or 'docs/decisions/0012-*.md') OR stage the ADR file itself."
-    fi
+if ! gov_rule2_issue_ref "$msg_subject" "$msg_body" "$branch"; then
+    deny "$GOV_REASON"
+fi
+
+if ! gov_rule3_adr_ref "$msg_subject" "$msg_body" "$staged"; then
+    deny "$GOV_REASON"
 fi
 
 # --- Anti-patterns reminder (non-blocking, exit 0) ---

--- a/bootstrap/hooks/governance-rules-lib.sh
+++ b/bootstrap/hooks/governance-rules-lib.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+# (SC2034: GOV_REASON is this library's out-parameter — assigned here, read by sourcing hooks.)
+#
+# governance-rules-lib.sh — shared implementation of governance Rules 1-3.
+#
+# Single source of truth for the rules previously duplicated verbatim between:
+#   bootstrap/hooks/pre-commit-governance.sh  (Claude Code PreToolUse, phase 1)
+#   bootstrap/hooks/commit-msg-governance.sh  (git commit-msg hook, phase 2, ADR-0011)
+#
+# Deployment (matches the callers' lookup of "$(dirname $0)/governance-rules-lib.sh"):
+#   - in-repo:           bootstrap/hooks/  (next to both hooks)
+#   - universal layer:   ~/.claude/hooks/  (hooks copy loop picks up every *.sh)
+#   - commit-msg staged: ~/.claude/git-hooks/  (staged by universal-setup.sh --install)
+#   - per-repo install:  .git/hooks/  (copied by universal-setup.sh --hook-this-repo)
+#
+# Library contract:
+#   - Sourcing has no side effects: defines functions and constants only, never exits.
+#   - Each gov_rule* returns 0 (pass) or 1 (violation) and sets GOV_REASON on violation.
+#   - Callers own the deny mechanism (exit 1 to git vs JSON + exit 2 to Claude Code).
+#   - No `set -e/-u` assumptions beyond using only declared locals and parameters.
+
+GOV_CC_REGEX='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|adr)(\([a-z0-9_.-]+\))?!?:[[:space:]].+'
+
+# Paths whose staged presence marks a commit as decision-type (Rule 3 trigger).
+GOV_DECISION_MARKERS=(
+    "docs/decisions/"
+    "go.mod"
+    "pyproject.toml"
+    "Cargo.toml"
+    "package.json"
+    ".github/workflows/"
+    "docs/domain/"
+)
+
+# Denial messages embed the staged-file list; bound it so the message stays
+# readable in terminals and safe to interpolate into JSON deny payloads.
+# The full list is always available via `git diff --cached --name-only`.
+GOV_STAGED_DISPLAY_LIMIT=200
+
+GOV_REASON=""
+
+# gov_is_adr_commit <subject> → 0 if the subject is an adr-type commit (adr: / adr(scope):)
+gov_is_adr_commit() {
+    echo "${1:-}" | grep -qE '^adr(\(|:)'
+}
+
+# Rule 1: Conventional Commits prefix on the subject line.
+# gov_rule1_conventional_commits <subject>
+gov_rule1_conventional_commits() {
+    local subject="${1:-}"
+    GOV_REASON=""
+    if echo "$subject" | grep -qE "$GOV_CC_REGEX"; then
+        return 0
+    fi
+    GOV_REASON="Rule 1: message does not follow Conventional Commits. Expected: type(scope?)!?: subject. Allowed types: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|adr. Got: '$subject'"
+    return 1
+}
+
+# Rule 2: issue reference (#NNN) in message body or digits in branch name.
+# Exempt: adr-type commits (the ADR is the primary artifact) and
+# bootstrap/initial meta-commits (word-boundary match, so "reinitialize" does not bypass).
+# gov_rule2_issue_ref <subject> <body> <branch>
+gov_rule2_issue_ref() {
+    local subject="${1:-}" body="${2:-}" branch="${3:-}"
+    GOV_REASON=""
+    if gov_is_adr_commit "$subject"; then
+        return 0
+    fi
+    if echo "$body" | grep -qE '\b(bootstrap|initial)\b'; then
+        return 0
+    fi
+    if echo "$body" | grep -qE '#[0-9]+'; then
+        return 0
+    fi
+    if echo "$branch" | grep -qE '[0-9]+'; then
+        return 0
+    fi
+    GOV_REASON="Rule 2: message or branch name must reference an issue (#NNN). Got subject: '$subject', branch: '$branch'"
+    return 1
+}
+
+# Rule 3: decision-type staged changes must reference an ADR in the message
+# body or stage an ADR file in the same commit.
+# Exempt: adr-type commits (self-referencing).
+# gov_rule3_adr_ref <subject> <body> <staged-file-list>
+gov_rule3_adr_ref() {
+    local subject="${1:-}" body="${2:-}" staged="${3:-}"
+    local marker is_decision_change=false
+    GOV_REASON=""
+    if gov_is_adr_commit "$subject"; then
+        return 0
+    fi
+    for marker in "${GOV_DECISION_MARKERS[@]}"; do
+        if echo "$staged" | grep -qF "$marker"; then
+            is_decision_change=true
+            break
+        fi
+    done
+    if [ "$is_decision_change" = "false" ]; then
+        return 0
+    fi
+    if echo "$body" | grep -qiE 'adr[ -]?[0-9]+|docs/decisions/[0-9]+'; then
+        return 0
+    fi
+    if echo "$staged" | grep -qE '^docs/decisions/[0-9]+-.*\.md$'; then
+        return 0
+    fi
+    GOV_REASON="Rule 3: decision-type change detected (staged: $(echo "$staged" | tr '\n' ' ' | head -c "$GOV_STAGED_DISPLAY_LIMIT")). Commit must reference an ADR (e.g., 'Implements ADR-0012' or 'docs/decisions/0012-*.md') OR stage the ADR file itself."
+    return 1
+}

--- a/bootstrap/hooks/pre-commit-governance.sh
+++ b/bootstrap/hooks/pre-commit-governance.sh
@@ -28,6 +28,13 @@ if [ -f "$_GATE_AUDIT_LIB" ]; then
 fi
 unset _GATE_AUDIT_LIB
 
+# --- Shared governance rules 1-3 (fail-closed below, after json_deny is defined) ---
+_RULES_LIB="$_SELF_DIR/governance-rules-lib.sh"
+if [ -f "$_RULES_LIB" ]; then
+    # shellcheck source=/dev/null
+    source "$_RULES_LIB"
+fi
+
 # --- Helpers ---
 
 json_deny() {
@@ -132,75 +139,26 @@ if [ -z "$msg" ]; then
     json_deny "Commit without -m flag not allowed from Claude (would open editor). Use: git commit -m \"<type>: <subject> (#NNN)\""
 fi
 
-# --- Rule 1: Conventional Commits prefix ---
+# --- Rules 1-3 (shared logic: governance-rules-lib.sh) ---
+# Fail-closed: a missing rules library means no governance — deny, do not pass through.
 
-cc_regex='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|adr)(\([a-z0-9_.-]+\))?!?:[[:space:]].+'
-
-if ! echo "$msg" | grep -qE "$cc_regex"; then
-    json_deny "Commit message does not follow Conventional Commits. Expected: type(scope?)!?: subject. Allowed types: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|adr. Got: '$msg'"
+if ! command -v gov_rule1_conventional_commits >/dev/null 2>&1; then
+    json_deny "pre-commit-governance: governance-rules-lib.sh missing at $_RULES_LIB. Re-run: ./bootstrap/universal-setup.sh --install"
 fi
-
-# --- Rule 2: Issue reference ---
-
-has_issue_ref=false
-if echo "$msg" | grep -qE '#[0-9]+'; then
-    has_issue_ref=true
-fi
-if echo "$branch" | grep -qE '[0-9]+'; then
-    has_issue_ref=true
-fi
-
-# ADR-commits и bootstrap не требуют issue-ref (сам ADR — первичный артефакт)
-if ! echo "$msg" | grep -qE '^adr(\(|:)' && ! echo "$msg" | grep -qE 'bootstrap|initial'; then
-    if [ "$has_issue_ref" = "false" ]; then
-        json_deny "Commit message or branch name must reference an issue (#NNN). Got message: '$msg', branch: '$branch'"
-    fi
-fi
-
-# --- Rule 3: ADR reference for decision-type changes ---
-
-# Decision-type changes: изменения в docs/decisions/, или в файлах, помеченных как
-# architecture/data-model/dependencies. Проверяем staged files.
 
 staged=$(git diff --cached --name-only 2>/dev/null || echo "")
 
-decision_markers=(
-    "docs/decisions/"
-    "go.mod"
-    "pyproject.toml"
-    "Cargo.toml"
-    "package.json"
-    ".github/workflows/"
-    "docs/domain/"
-)
-
-is_decision_change=false
-for marker in "${decision_markers[@]}"; do
-    if echo "$staged" | grep -qF "$marker"; then
-        is_decision_change=true
-        break
-    fi
-done
-
-# ADR-commits сами себе reference — пропускаем
-if echo "$msg" | grep -qE '^adr(\(|:)'; then
-    is_decision_change=false
+# `git commit -m` carries a single message string: it is both subject and body here.
+if ! gov_rule1_conventional_commits "$msg"; then
+    json_deny "$GOV_REASON"
 fi
 
-if [ "$is_decision_change" = "true" ]; then
-    has_adr_ref=false
-    # Ссылка на ADR в message
-    if echo "$msg" | grep -qiE 'adr[ -]?[0-9]+|docs/decisions/[0-9]+'; then
-        has_adr_ref=true
-    fi
-    # ИЛИ ADR staged в этом же коммите
-    if echo "$staged" | grep -qE '^docs/decisions/[0-9]+-.*\.md$'; then
-        has_adr_ref=true
-    fi
+if ! gov_rule2_issue_ref "$msg" "$msg" "$branch"; then
+    json_deny "$GOV_REASON"
+fi
 
-    if [ "$has_adr_ref" = "false" ]; then
-        json_deny "Decision-type change detected (staged: $(echo "$staged" | tr '\n' ' ' | head -c 200)). Commit must reference an ADR (e.g., 'Implements ADR-0012' or 'docs/decisions/0012-*.md') OR stage the ADR itself."
-    fi
+if ! gov_rule3_adr_ref "$msg" "$msg" "$staged"; then
+    json_deny "$GOV_REASON"
 fi
 
 # --- Rule H: Hedging language in plan.md / STATE.md / docs/decisions/*.md ---

--- a/bootstrap/scripts/test-commit-msg-governance.sh
+++ b/bootstrap/scripts/test-commit-msg-governance.sh
@@ -218,7 +218,9 @@ echo ""
 # ===== --hook-this-repo INSTALLER MODE =====
 echo "--hook-this-repo installer mode"
 
-INSTALLER="$(dirname "$0")/../../bootstrap/universal-setup.sh"
+# Canonicalize like HOOK above: HTR tests cd into sandbox repos, a relative
+# installer path stops resolving there (manifested as exit 127).
+INSTALLER="$(cd "$(dirname "$0")/../.." && pwd)/bootstrap/universal-setup.sh"
 if [ ! -f "$INSTALLER" ]; then
     echo "  (installer not found at $INSTALLER — HTR tests skipped; run from repo root to include them)"
 else
@@ -227,6 +229,9 @@ else
     mkdir -p "$FAKE_HOME/.claude/git-hooks"
     cp "$HOOK" "$FAKE_HOME/.claude/git-hooks/commit-msg"
     chmod +x "$FAKE_HOME/.claude/git-hooks/commit-msg"
+    # The hook ships as a pair with the shared rules lib (sourced from its own dir);
+    # --hook-this-repo requires both staged.
+    cp "$(dirname "$HOOK")/governance-rules-lib.sh" "$FAKE_HOME/.claude/git-hooks/governance-rules-lib.sh"
     trap 'rm -rf "$TMPDIR_REPO" "$TMPDIR_HOME" "$TMPDIR_REPO2" "$FAKE_HOME"' EXIT
 
     INSTALL_REPO=$(mktemp -d)

--- a/bootstrap/scripts/test-install-verification.sh
+++ b/bootstrap/scripts/test-install-verification.sh
@@ -56,6 +56,8 @@ DEST_HOOK="$FAKE_REPO/.git/hooks/commit-msg"
 mkdir -p "$FAKE_HOME/.claude/git-hooks"
 printf '#!/bin/bash\n# test staged hook\nexit 0\n' > "$STAGED_HOOK"
 chmod +x "$STAGED_HOOK"
+# --hook-this-repo requires the shared rules lib staged next to the hook (deployed as a pair)
+printf '#!/bin/bash\n# test staged rules lib\n' > "$FAKE_HOME/.claude/git-hooks/governance-rules-lib.sh"
 
 # 2a: clean install — should succeed and install matching hook
 if (cd "$FAKE_REPO" && HOME="$FAKE_HOME" bash "$SETUP" --hook-this-repo >/dev/null 2>&1); then

--- a/bootstrap/universal-setup.sh
+++ b/bootstrap/universal-setup.sh
@@ -91,10 +91,11 @@ fi
 # Handled separately before prerequisite checks to keep it lightweight.
 if [ "$MODE" = "hook-this-repo" ]; then
     STAGED_HOOK="$HOME/.claude/git-hooks/commit-msg"
+    STAGED_RULES_LIB="$HOME/.claude/git-hooks/governance-rules-lib.sh"
 
-    if [ ! -f "$STAGED_HOOK" ]; then
-        err "Staged hook not found: $STAGED_HOOK"
-        echo "  Run './bootstrap/universal-setup.sh --install' first to stage the hook." >&2
+    if [ ! -f "$STAGED_HOOK" ] || [ ! -f "$STAGED_RULES_LIB" ]; then
+        err "Staged hook artifacts not found: need both $STAGED_HOOK and $STAGED_RULES_LIB"
+        echo "  Run './bootstrap/universal-setup.sh --install' first to stage them." >&2
         exit 2
     fi
 
@@ -103,29 +104,36 @@ if [ "$MODE" = "hook-this-repo" ]; then
         exit 3
     }
     DEST_HOOK="$GIT_DIR/hooks/commit-msg"
+    DEST_RULES_LIB="$GIT_DIR/hooks/governance-rules-lib.sh"
 
     mkdir -p "$GIT_DIR/hooks"
 
-    if [ -f "$DEST_HOOK" ] && ! cmp -s "$STAGED_HOOK" "$DEST_HOOK"; then
+    # Symmetric drift guard: the hook and its rules lib deploy as a pair, so a
+    # locally modified copy of either one requires --force to overwrite.
+    if { [ -f "$DEST_HOOK" ] && ! cmp -s "$STAGED_HOOK" "$DEST_HOOK"; } \
+        || { [ -f "$DEST_RULES_LIB" ] && ! cmp -s "$STAGED_RULES_LIB" "$DEST_RULES_LIB"; }; then
         if [ "$FORCE" != "1" ]; then
-            warn "A different commit-msg hook already exists at $DEST_HOOK"
-            echo "  Use --force to overwrite, or inspect with: diff $DEST_HOOK $STAGED_HOOK" >&2
+            warn "A different commit-msg hook or rules lib already exists in $GIT_DIR/hooks/"
+            echo "  Use --force to overwrite, or inspect with: diff $DEST_HOOK $STAGED_HOOK; diff $DEST_RULES_LIB $STAGED_RULES_LIB" >&2
             exit 4
         fi
-        warn "Overwriting existing commit-msg hook (--force)"
+        warn "Overwriting existing commit-msg hook/rules lib (--force)"
     fi
 
-    if [ -f "$DEST_HOOK" ] && cmp -s "$STAGED_HOOK" "$DEST_HOOK"; then
-        ok "commit-msg hook already installed and up-to-date"
+    if [ -f "$DEST_HOOK" ] && cmp -s "$STAGED_HOOK" "$DEST_HOOK" \
+        && [ -f "$DEST_RULES_LIB" ] && cmp -s "$STAGED_RULES_LIB" "$DEST_RULES_LIB"; then
+        ok "commit-msg hook + rules lib already installed and up-to-date"
         exit 0
     fi
 
     cp "$STAGED_HOOK" "$DEST_HOOK" || die "cp failed: $DEST_HOOK"
     chmod +x "$DEST_HOOK" || die "chmod failed: $DEST_HOOK"
     cmp -s "$STAGED_HOOK" "$DEST_HOOK" || die "post-copy verification failed: $DEST_HOOK"
-    ok "commit-msg governance hook installed → $DEST_HOOK"
+    cp "$STAGED_RULES_LIB" "$DEST_RULES_LIB" || die "cp failed: $DEST_RULES_LIB"
+    cmp -s "$STAGED_RULES_LIB" "$DEST_RULES_LIB" || die "post-copy verification failed: $DEST_RULES_LIB"
+    ok "commit-msg governance hook + rules lib installed → $DEST_HOOK"
     echo "  To verify: git commit -m 'bad message' (should be blocked)"
-    echo "  To remove: rm $DEST_HOOK"
+    echo "  To remove: rm $DEST_HOOK $DEST_RULES_LIB"
     exit 0
 fi
 
@@ -447,6 +455,16 @@ if [ -f "$COMMIT_MSG_SRC" ]; then
     fi
 else
     warn "commit-msg-governance.sh not found in bootstrap/hooks/ — skipping"
+fi
+
+# The shared rules lib must sit next to the staged hook: the hook sources it
+# from its own directory (fail-closed), and --hook-this-repo copies the pair.
+RULES_LIB_SRC="$REPO_ROOT/bootstrap/hooks/governance-rules-lib.sh"
+RULES_LIB_STAGE_DST="$CLAUDE_HOME/git-hooks/governance-rules-lib.sh"
+if [ -f "$RULES_LIB_SRC" ]; then
+    copy_file "$RULES_LIB_SRC" "$RULES_LIB_STAGE_DST"
+else
+    warn "governance-rules-lib.sh not found in bootstrap/hooks/ — commit-msg hook will fail closed"
 fi
 
 # --- Copy scripts ---


### PR DESCRIPTION
Closes #256
Governed by ADR-0004 (PreToolUse governance) / ADR-0011 (git-level phase 2) — поведенческий контракт не меняется, дублирование устранено.

## Что сделано
- **Новая `bootstrap/hooks/governance-rules-lib.sh`** — единственный источник Rules 1–3 (CC-префикс, issue-ref, ADR-ref). Контракт: функции `gov_rule*` возвращают 0/1 и заполняют `GOV_REASON`; механизм deny остаётся за вызывающим (exit 1 для git против JSON+exit 2 для Claude Code).
- Оба hook'а source'ят lib из собственной директории, **fail-closed** при отсутствии.
- `universal-setup.sh`: lib стейджится рядом с commit-msg hook; `--hook-this-repo` ставит пару с симметричным drift-guard (--force нужен при отличии любого из двух файлов) и cmp-постверификацией. Цикл копирования hooks автоматически доставляет lib в `~/.claude/hooks/` для pre-commit.
- Тест-харнессы стейджат lib в песочницах; путь INSTALLER канонизирован в absolute (починен pre-existing exit-127 при относительном запуске).

## Сознательная унификация (единственное изменение семантики)
Pre-commit Rule 2: исключение bootstrap/initial ужесточено с подстроки до word-boundary (`\b(bootstrap|initial)\b`) — «reinitialize» больше не обходит правило. commit-msg уже использовал word-boundary; унификация в сторону строгого варианта.

## Reviews (prod-bound гейты)
| Агент | Вердикт |
|---|---|
| security-reviewer | APPROVE (1 WARNING: json_deny экранирует только кавычки — pre-existing, follow-up кандидат) |
| reliability-reviewer | APPROVE (SUGGEST по симметрии --force — исправлено в этом же PR) |
| adversarial-critic | BLOCK → исправлено (магическая константа 200 → `GOV_STAGED_DISPLAY_LIMIT` с комментарием) |

## Проверки
- shellcheck: clean (вкл. installer)
- test-commit-msg-governance.sh: all passed (33 теста, вкл. HTR-секцию)
- test-governance-hook.sh: all passed
- test-install-verification.sh: all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)