### PR TITLE
feat(preflight): return ritual — accumulated-while-away report in mini-preflight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,17 @@ jobs:
             exit 1
           fi
 
+  mini-preflight-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+      - name: Run mini-preflight test suite
+        run: bash bootstrap/scripts/test-mini-preflight.sh
+
   gate-audit-test:
     runs-on: ubuntu-latest
     steps:

--- a/bootstrap/scripts/mini-preflight.sh
+++ b/bootstrap/scripts/mini-preflight.sh
@@ -99,6 +99,107 @@ else
     fail "claude бинарь не найден в PATH"
 fi
 
+# --- «Ритуал возвращения»: что накопилось, пока оператора не было (#257) ---
+# Report-only: секция никогда не меняет exit-код (не трогает $failed) и ничего
+# не мутирует. Деградация по Принципу 9: любой сбой gh/jq → warn + пропуск секции.
+report_accumulated() {
+    local repo_root tc
+    repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 0  # вне git-репо секции нет
+
+    echo ""
+    echo "Что накопилось за отсутствие ($(basename "$repo_root")):"
+
+    if ! command -v jq >/dev/null 2>&1; then
+        warn "jq не найден — секция пропущена"
+        return 0
+    fi
+    # timeout-обёртка: gh без сети может висеть десятки секунд, а preflight интерактивен.
+    # Не переиспользуем _tc из codex-блока выше: тот инициализируется только в своей
+    # ветке и под set -u здесь был бы unbound.
+    tc=$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || echo "")
+    _gh() {
+        # 15s: дольше codex-овых 10s — gh run list на холодном TCP заметно медленнее
+        if [ -n "$tc" ]; then "$tc" 15 gh "$@" 2>/dev/null; else gh "$@" 2>/dev/null; fi
+    }
+
+    # --- Локальные подсекции (работают и офлайн — до gh-гейта) ---
+
+    # Дней с последней сессии — по имени последнего session-log файла (YYYY-MM-DD)
+    local last_log last_date days_away
+    last_log=$(find "$repo_root/session-log" -name '*.md' 2>/dev/null | sort | tail -1)
+    if [ -n "$last_log" ]; then
+        last_date=$(basename "$last_log" .md)
+        days_away=$(jq -rn --arg d "$last_date" '((now - (($d + "T00:00:00Z") | fromdate)) / 86400 | floor)' 2>/dev/null || echo "")
+        if [ -n "$days_away" ]; then
+            if [ "$days_away" -gt 7 ]; then  # неделя: дольше — пауза, а не выходные
+                warn "$days_away дней с последней сессии ($last_date)"
+            else
+                ok "$days_away дн. с последней сессии ($last_date)"
+            fi
+        fi
+    fi
+
+    # Proposed-ADR с возрастом из строки '* Date:' — чисто локальный grep,
+    # сознательно ДО gh-гейта: офлайн-оператор должен видеть протухшие ADR
+    local adr_file adr_date adr_age
+    for adr_file in "$repo_root"/docs/decisions/[0-9]*.md; do
+        [ -f "$adr_file" ] || continue
+        if grep -q '^\* Status: proposed' "$adr_file"; then
+            adr_date=$(grep -m1 '^\* Date:' "$adr_file" | sed 's/^\* Date:[[:space:]]*//')
+            adr_age=$(jq -rn --arg d "$adr_date" '((now - (($d + "T00:00:00Z") | fromdate)) / 86400 | floor)' 2>/dev/null || echo "?")
+            warn "proposed ADR: $(basename "$adr_file") — $adr_age дн."
+        fi
+    done
+
+    # --- Сетевые подсекции (gh-гейт) ---
+
+    if ! command -v gh >/dev/null 2>&1 || ! _gh auth status >/dev/null; then
+        warn "gh недоступен — CI/issues/PR секции пропущены (офлайн-режим, Принцип 9)"
+        return 0
+    fi
+
+    # CI: последний прогон каждого workflow; limit 50, чтобы редкие scheduled-прогоны
+    # не выпадали из окна в активный день. Красное = любой завершившийся не-success
+    # (failure, cancelled, timed_out, startup_failure); in-progress (conclusion == "")
+    # не красим. max_by(.createdAt) — не полагаемся на порядок вывода gh.
+    local runs red_lines ok_lines line
+    if runs=$(_gh run list --limit 50 --json workflowName,status,conclusion,createdAt) && [ -n "$runs" ]; then
+        red_lines=$(echo "$runs" | jq -r 'group_by(.workflowName) | map(max_by(.createdAt)) | .[] | select(.conclusion != "success" and .conclusion != "") | "\(.workflowName): \(.conclusion) (\(.createdAt[:10]))"')
+        ok_lines=$(echo "$runs" | jq -r 'group_by(.workflowName) | map(max_by(.createdAt)) | .[] | select(.conclusion == "success" or .conclusion == "") | "\(.workflowName): \(if .conclusion == "" then .status else .conclusion end) (\(.createdAt[:10]))"')
+        if [ -n "$red_lines" ]; then
+            while IFS= read -r line; do warn "CI: $line"; done <<<"$red_lines"
+        fi
+        if [ -n "$ok_lines" ]; then
+            while IFS= read -r line; do ok "CI: $line"; done <<<"$ok_lines"
+        fi
+    else
+        warn "gh run list не ответил — CI-секция пропущена"
+    fi
+
+    # Авто-issues (mutation weekly, deferred-review): OR-фильтр через jq —
+    # несколько --label у gh issue list означают AND, не OR.
+    # gsub: вычищаем control-символы из заголовков (ANSI-смаглинг в терминал).
+    local auto_issues
+    if auto_issues=$(_gh issue list --state open --limit 100 --json number,title,createdAt,labels); then  # 100: с запасом против дефолтных 30 — в репо уже ~30 открытых
+        echo "$auto_issues" | jq -r '.[] | select(.labels | any(.name == "type:mutation-report" or .name == "type:deferred-review")) | "#\(.number) \(.title[:60] | gsub("[\\u0000-\\u001F\\u007F]"; "")) — \((now - (.createdAt | fromdate)) / 86400 | floor) дн."' \
+            | while IFS= read -r line; do [ -n "$line" ] && warn "не прочитано: $line"; done
+    else
+        warn "gh issue list не ответил — auto-issue секция пропущена"
+    fi
+
+    # Открытые PR с возрастом (gsub — та же чистка control-символов)
+    local prs
+    if prs=$(_gh pr list --json number,title,createdAt); then
+        echo "$prs" | jq -r '.[] | "#\(.number) \(.title[:60] | gsub("[\\u0000-\\u001F\\u007F]"; "")) — \((now - (.createdAt | fromdate)) / 86400 | floor) дн."' \
+            | while IFS= read -r line; do [ -n "$line" ] && warn "открыт PR: $line"; done
+    else
+        warn "gh pr list не ответил — PR-секция пропущена"
+    fi
+
+    return 0
+}
+report_accumulated
+
 echo ""
 if [ $failed -eq 0 ]; then
     printf '%sГотов к сессии.%s\n' "$GREEN" "$NC"

--- a/bootstrap/scripts/test-mini-preflight.sh
+++ b/bootstrap/scripts/test-mini-preflight.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# test-mini-preflight.sh — smoke-test for the report_accumulated section of mini-preflight.sh (#257)
+#
+# Verifies that the "что накопилось за отсутствие" section:
+#   - is skipped silently outside a git repo
+#   - computes days-since-last-session from session-log filenames
+#   - lists proposed ADRs with age
+#   - degrades with a warn (not a crash, not an exit-code change) when gh is absent
+#
+# Network calls are NOT mocked — only degradation paths and local math are tested.
+# The env-check half of mini-preflight (keychain, auth, claude) is environment-
+# dependent; these tests assert on section output, not on the overall exit code.
+# The report-only exit-code invariant is asserted structurally in T4 (the function
+# body must never reference the failed counter), because a broken gh also fails
+# the env-check half by design and a black-box exit-code comparison cannot
+# isolate the section's contribution.
+#
+# Usage:
+#   bash bootstrap/scripts/test-mini-preflight.sh
+#
+# Exit codes: 0 = all tests passed, 1 = one or more failures
+
+set -uo pipefail
+
+# Canonicalize so cd into sandboxes doesn't break invocation
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/mini-preflight.sh"
+
+RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; NC=$'\033[0m'
+pass() { printf "  ${GREEN}✓${NC} %s\n" "$1"; }
+fail() { printf "  ${RED}✗${NC} %s\n" "$1"; FAILURES=$((FAILURES+1)); }
+
+FAILURES=0
+
+if [ ! -f "$SCRIPT" ]; then
+    printf "${RED}FATAL:${NC} mini-preflight.sh not found at %s\n" "$SCRIPT" >&2
+    exit 1
+fi
+
+echo "=== test-mini-preflight ==="
+echo "Script: $SCRIPT"
+echo ""
+
+# ---- T1: syntax ----
+echo "T1: syntax"
+if bash -n "$SCRIPT"; then
+    pass "bash -n clean"
+else
+    fail "bash -n reported syntax errors"
+fi
+
+# ---- Sandboxes ----
+NONGIT_DIR=$(mktemp -d /tmp/claude-mini-preflight-nongit-XXXXXX)
+REPO_DIR=$(mktemp -d /tmp/claude-mini-preflight-repo-XXXXXX)
+trap 'rm -rf "$NONGIT_DIR" "$REPO_DIR"' EXIT
+
+git -C "$REPO_DIR" init -q
+mkdir -p "$REPO_DIR/session-log/2026/01"
+# Fixed old date → days-away is large and deterministic (> 7)
+touch "$REPO_DIR/session-log/2026/01/2026-01-01.md"
+mkdir -p "$REPO_DIR/docs/decisions"
+printf '# 0001. Test decision\n\n* Status: proposed\n* Date: 2026-01-01\n' \
+    > "$REPO_DIR/docs/decisions/0001-test-decision.md"
+
+# ---- T2: outside a git repo the section is absent ----
+echo ""
+echo "T2: non-git directory"
+out=$(cd "$NONGIT_DIR" && bash "$SCRIPT" 2>/dev/null || true)
+if echo "$out" | grep -q "Что накопилось"; then
+    fail "section printed outside a git repo"
+else
+    pass "section silently skipped outside a git repo"
+fi
+
+# ---- T3: days-since-last-session from session-log filename ----
+echo ""
+echo "T3: days-since-last-session math"
+out=$(cd "$REPO_DIR" && bash "$SCRIPT" 2>/dev/null || true)
+if echo "$out" | grep -q "Что накопилось"; then
+    pass "section header printed inside a git repo"
+else
+    fail "section header missing inside a git repo"
+fi
+if echo "$out" | grep -qE 'дн(ей|\.) с последней сессии \(2026-01-01\)'; then
+    pass "days-away computed from session-log filename"
+else
+    fail "days-away line missing or malformed; got: $(echo "$out" | grep 'сесси' || echo '<none>')"
+fi
+
+# ---- T4: gh unusable (offline) → warn + same exit code as with working gh ----
+# A broken-gh shim is prepended to PATH instead of stripping gh's directory:
+# stripping the directory would also remove unrelated tools (claude, tailscale)
+# and change the env-check half's exit code for reasons unrelated to gh.
+echo ""
+echo "T4: degradation with unusable gh (offline simulation)"
+SHIM_DIR=$(mktemp -d /tmp/claude-mini-preflight-shim-XXXXXX)
+trap 'rm -rf "$NONGIT_DIR" "$REPO_DIR" "$SHIM_DIR"' EXIT
+printf '#!/bin/sh\nexit 1\n' > "$SHIM_DIR/gh"
+chmod +x "$SHIM_DIR/gh"
+out=$(cd "$REPO_DIR" && PATH="$SHIM_DIR:$PATH" bash "$SCRIPT" 2>/dev/null) || true
+if echo "$out" | grep -q "gh недоступен"; then
+    pass "unusable gh degrades with warn"
+else
+    fail "gh-degradation warn missing; got: $(echo "$out" | tail -5 | tr '\n' ' ')"
+fi
+if echo "$out" | grep -qE 'Готов к сессии|блокирующих проблем'; then
+    pass "script reaches final status line despite gh degradation (no mid-section crash)"
+else
+    fail "script did not reach final status line with broken gh"
+fi
+# Exit-code invariance is structural: the section must never touch the failed
+# counter (a broken gh also fails the env-check half by design, so a black-box
+# exit-code comparison cannot isolate the section's contribution).
+if awk '/^report_accumulated\(\)/,/^\}/' "$SCRIPT" | grep -qw 'failed'; then
+    fail "report_accumulated references the failed counter — section must be report-only"
+else
+    pass "report_accumulated never touches the failed counter (report-only invariant)"
+fi
+
+# ---- T5: proposed ADR listed with age ----
+echo ""
+echo "T5: proposed ADR listing"
+out=$(cd "$REPO_DIR" && bash "$SCRIPT" 2>/dev/null || true)
+if echo "$out" | grep -q "proposed ADR: 0001-test-decision.md"; then
+    pass "proposed ADR listed"
+else
+    fail "proposed ADR not listed; got: $(echo "$out" | grep -i adr || echo '<none>')"
+fi
+
+echo ""
+echo "=== Summary ==="
+if [ "$FAILURES" -eq 0 ]; then
+    printf '%sAll tests passed%s\n' "$GREEN" "$NC"
+    exit 0
+else
+    printf '%s%d test(s) failed%s\n' "$RED" "$FAILURES" "$NC"
+    exit 1
+fi

--- a/docs/runbooks/resume-drill.md
+++ b/docs/runbooks/resume-drill.md
@@ -35,8 +35,16 @@ sessions, or whenever the human-resume contract is questioned.
 
 **Steps:**
 
+0. Run `mini-preflight` from the repo root (#257). Its «Что накопилось за отсутствие»
+   section is the return-ritual companion to STATE.md: days since last session, the
+   latest run of every CI workflow (red first, including scheduled ones that fail
+   silently for weeks), unread auto-issues (mutation weekly, deferred-review), open
+   PRs, and proposed ADRs with age. STATE.md answers "where did I stop"; this section
+   answers "what did the system accumulate while I was away". Offline it degrades to
+   a warn and skips — the drill itself never depends on the network.
+
 1. Open a new terminal / clean session. Do NOT look at chat history, PR descriptions,
-   or any context beyond `STATE.md` and today's `session-log` entry.
+   or any context beyond `STATE.md`, today's `session-log` entry, and the preflight output.
 
 2. Start a 5-minute timer.
 
@@ -118,6 +126,7 @@ After each drill, append a row to this table:
 
 - `STATE.md` — aggregate root (Session Continuity BC)
 - `session-log/YYYY/MM/YYYY-MM-DD.md` — append-only history
+- `bootstrap/scripts/mini-preflight.sh` — return ritual: «что накопилось за отсутствие» (#257)
 - `bootstrap/scripts/plan-lint.sh` — linter for plan.md ADR-discipline (third leg of hand-off)
 - `bootstrap/hooks/stop-hook.sh` — automates mechanical STATE.md field updates
 - `docs/decisions/0024-session-continuity-bc-and-state-schema.md` — ADR governing all of the above


### PR DESCRIPTION
Closes #257
Extends docs/decisions/0024-session-continuity-bc-and-state-schema.md (Принцип 9): STATE.md отвечает «где я остановился», новая секция — «что система накопила, пока меня не было».

## Что сделано
`report_accumulated()` в mini-preflight.sh — один экран при возвращении к станку:
- дней с последней сессии (по имени session-log файла)
- последний прогон **каждого** CI workflow, красные первыми — ловит молча падающие scheduled-прогоны (кейс: ADR-audit был красным 4 понедельника, никто не видел)
- непрочитанные авто-issues (mutation weekly / deferred-review) с возрастом
- открытые PR с возрастом
- proposed-ADR с возрастом — работает и офлайн (до gh-гейта)

Контракт: **report-only** — секция не трогает счётчик `failed` (инвариант закреплён структурным тестом), exit-семантика mini-preflight не меняется (трактовка AC зафиксирована комментарием в #257). Деградация по Принципу 9: gh-вызовы под 15s timeout, любой сбой → warn с именем пропущенной подсекции.

## Pipeline
- plan.md (6 секций) → advisor №1 (поймал: CI без auto-discovery тестов, globstar на macOS bash 3.2, AND-семантику --label, выпадение scheduled из --limit 20) → implement → qa-report → advisor №2 (поймал блокер: ADR-блок был недостижим офлайн и валил бы T5 в CI) → гейты.

## Reviews (prod-bound)
| Гейт | Вердикт |
|---|---|
| advisor ×2 | план скорректирован; блокер пре-done исправлен |
| security-reviewer | APPROVE (WARNING про ANSI-смаглинг через заголовки — закрыт gsub-чисткой control-символов) |
| reliability-reviewer | APPROVE (SUGGEST про тихие пропуски issue/PR-секций и max_by — оба внесены) |
| adversarial-critic | BLOCK → исправлено (константы 15s/7d/100 с same-line комментариями) |

## QA
- test-mini-preflight.sh: 8/8 (синтаксис, non-git skip, date-математика, gh-деградация ×3, proposed-ADR)
- shellcheck clean; CI job `mini-preflight-test` добавлен
- Живой прогон в claude-mini: секция сразу поймала **новый** красный workflow (Project board sync, 2026-06-10) и 6 непрочитанных авто-issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)